### PR TITLE
Add navigation to pictures in builds

### DIFF
--- a/projects/commudle-admin/src/app/feature-modules/community-builds/components/community-build-details/community-build-details.component.html
+++ b/projects/commudle-admin/src/app/feature-modules/community-builds/components/community-build-details/community-build-details.component.html
@@ -41,7 +41,7 @@
       </div>
       <div class="images" *ngIf="cBuild.images.length > 0">
         <div class="image-stripe">
-          <div class="image clickable" *ngFor="let image of cBuild.images" (click)="openImage(cBuild.name, image.url)">
+          <div class="image clickable" *ngFor="let image of cBuild.images" (click)="openImage(cBuild.name, image)">
             <img src="{{ image.url }}" alt="{{ cBuild.name }}">
           </div>
         </div>
@@ -75,12 +75,18 @@
 
 </div>
 
-<ng-template #imageTemplate let-data>
+<ng-template #imageTemplate>
   <div class="image-window">
-    <img src="{{data.imageUrl}}" alt="Image">
+    <img src="{{ this.currImage.url }}" alt="Image">
     <div class="controls">
-      <button nbButton size="small" (click)="imageNav(data.imageUrl, -1)">Previous</button>
-      <button nbButton size="small" (click)="imageNav(data.imageUrl, 1)">Next</button>
+      <button nbButton size="small" shape="round" (click)="imageNav(-1)">
+        <nb-icon icon="arrow-ios-back-outline"></nb-icon>
+        <span>Previous</span>
+      </button>
+      <button nbButton size="small" shape="round" (click)="imageNav(1)">
+        <span>Next</span>
+        <nb-icon icon="arrow-ios-forward-outline"></nb-icon>
+      </button>
     </div>
   </div>
 </ng-template>

--- a/projects/commudle-admin/src/app/feature-modules/community-builds/components/community-build-details/community-build-details.component.html
+++ b/projects/commudle-admin/src/app/feature-modules/community-builds/components/community-build-details/community-build-details.component.html
@@ -8,7 +8,7 @@
             [text]="cBuild.build_type | titlecase"
             [color]="CBuildTypeDisplay[cBuild.build_type].color"
             [nbIcon]="CBuildTypeDisplay[cBuild.build_type].icon"
-            >
+          >
           </app-badge>
         </div>
         <h1>
@@ -31,7 +31,8 @@
         <p>
           Visit the {{cBuild.build_type}}:
           <a target="_blank" href="{{ cBuild.link }}">
-            {{ cBuild.link }} <nb-icon icon="external-link"></nb-icon>
+            {{ cBuild.link }}
+            <nb-icon icon="external-link"></nb-icon>
           </a>
         </p>
       </div>
@@ -46,7 +47,8 @@
         </div>
       </div>
       <div class="author-details">
-        <app-user-profile-horizontal [user]="cBuild.user" [aboutMe]="true" [socialMediaLinks]="true"></app-user-profile-horizontal>
+        <app-user-profile-horizontal [user]="cBuild.user" [aboutMe]="true"
+                                     [socialMediaLinks]="true"></app-user-profile-horizontal>
       </div>
 
       <div class="stats">
@@ -56,7 +58,7 @@
             [votableId]="cBuild.id"
             [icon]="'star'"
             [size]="'large'"
-            >
+          >
           </app-votes-display>
           <span>
             Give a star to encourage!
@@ -75,6 +77,10 @@
 
 <ng-template #imageTemplate let-data>
   <div class="image-window">
-    <img src="{{data.imageUrl}}">
+    <img src="{{data.imageUrl}}" alt="Image">
+    <div class="controls">
+      <button nbButton size="small" (click)="imageNav(data.imageUrl, -1)">Previous</button>
+      <button nbButton size="small" (click)="imageNav(data.imageUrl, 1)">Next</button>
+    </div>
   </div>
 </ng-template>

--- a/projects/commudle-admin/src/app/feature-modules/community-builds/components/community-build-details/community-build-details.component.scss
+++ b/projects/commudle-admin/src/app/feature-modules/community-builds/components/community-build-details/community-build-details.component.scss
@@ -29,6 +29,7 @@
 
     .build-type {
       margin: 0 0 1rem;
+
       span {
         font-size: 0.8rem;
         padding: 5px 8px;
@@ -41,6 +42,7 @@
 
     .description {
       margin: 1rem 0 1rem;
+
       p {
         font-size: 1.5rem;
       }
@@ -51,10 +53,12 @@
       overflow-x: auto;
       margin-bottom: 1.5rem;
       background: #d3d3d33b;
+
       .image-stripe {
         display: flex;
         flex-wrap: nowrap;
         width: fit-content;
+
         .image {
           width: 280px;
           height: 280px;
@@ -63,6 +67,7 @@
           display: flex;
           align-items: center;
           margin: 0 0.5rem;
+
           img {
             width: 100%;
           }
@@ -76,6 +81,7 @@
       overflow: auto;
       display: flex;
       justify-content: center;
+
       iframe {
         width: 100% !important;
       }
@@ -83,8 +89,10 @@
 
     .link {
       margin-bottom: 1rem;
+
       p {
         margin: 0;
+
         a {
         }
       }
@@ -92,11 +100,13 @@
 
     .stats {
       display: flex;
-      >p {
+
+      > p {
         margin: 0.5rem 1rem 0 0;
         display: flex;
         align-items: center;
-        >span {
+
+        > span {
           margin-left: 0.5rem;
         }
       }
@@ -105,6 +115,7 @@
     .tags {
       display: flex;
       flex-wrap: wrap;
+
       app-badge {
         margin: 5px;
       }
@@ -117,19 +128,30 @@
     margin: 1rem 0;
     height: 35vh;
     min-height: 400px;
-    >p {
+
+    > p {
       margin: 0 0 1rem;
       font-size: 1.3rem;
       font-weight: 300;
     }
   }
-
 }
 
 
 .image-window {
   max-width: 100vw;
   overflow: hidden;
+
+  .controls {
+    text-align: center;
+    margin-top: 1rem;
+    margin-bottom: 1rem;
+
+    :nth-of-type(1) {
+      margin-right: 1rem;
+    }
+  }
+
   img {
     width: 100%;
   }

--- a/projects/commudle-admin/src/app/feature-modules/community-builds/components/community-build-details/community-build-details.component.scss
+++ b/projects/commudle-admin/src/app/feature-modules/community-builds/components/community-build-details/community-build-details.component.scss
@@ -137,18 +137,23 @@
   }
 }
 
-
 .image-window {
   max-width: 100vw;
   overflow: hidden;
 
   .controls {
-    text-align: center;
+    display: flex;
     margin-top: 1rem;
     margin-bottom: 1rem;
+    justify-content: space-between;
 
-    :nth-of-type(1) {
-      margin-right: 1rem;
+    button {
+      margin-left: 0.5rem;
+      margin-right: 0.5rem;
+    }
+
+    nb-icon {
+      vertical-align: top;
     }
   }
 

--- a/projects/commudle-admin/src/app/feature-modules/community-builds/components/community-build-details/community-build-details.component.spec.ts
+++ b/projects/commudle-admin/src/app/feature-modules/community-builds/components/community-build-details/community-build-details.component.spec.ts
@@ -1,6 +1,6 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import {async, ComponentFixture, TestBed} from '@angular/core/testing';
 
-import { CommunityBuildDetailsComponent } from './community-build-details.component';
+import {CommunityBuildDetailsComponent} from './community-build-details.component';
 
 describe('CommunityBuildDetailsComponent', () => {
   let component: CommunityBuildDetailsComponent;
@@ -8,9 +8,9 @@ describe('CommunityBuildDetailsComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ CommunityBuildDetailsComponent ]
+      declarations: [CommunityBuildDetailsComponent]
     })
-    .compileComponents();
+      .compileComponents();
   }));
 
   beforeEach(() => {

--- a/projects/commudle-admin/src/app/feature-modules/community-builds/components/community-build-details/community-build-details.component.ts
+++ b/projects/commudle-admin/src/app/feature-modules/community-builds/components/community-build-details/community-build-details.component.ts
@@ -1,6 +1,6 @@
 import {Component, Input, OnInit, TemplateRef, ViewChild} from '@angular/core';
 import * as moment from 'moment';
-import {NbWindowRef, NbWindowService} from '@nebular/theme';
+import {NbWindowService} from '@nebular/theme';
 import {DomSanitizer} from '@angular/platform-browser';
 import {CBuildTypeDisplay, EBuildType, ICommunityBuild} from 'projects/shared-models/community-build.model';
 import {DiscussionsService} from 'projects/commudle-admin/src/app/services/discussions.service';
@@ -24,7 +24,7 @@ export class CommunityBuildDetailsComponent implements OnInit {
   CBuildTypeDisplay = CBuildTypeDisplay;
   hasIframe = false;
   embedCode: any;
-  windowRef: NbWindowRef;
+  currImage = null;
 
   constructor(
     private windowService: NbWindowService,
@@ -42,32 +42,21 @@ export class CommunityBuildDetailsComponent implements OnInit {
     }
   }
 
-  openImage(title, url) {
-    this.windowRef = this.windowService.open(
+  openImage(title, image) {
+    this.currImage = image;
+    this.windowService.open(
       this.imageTemplate,
       {
         title,
-        context: {
-          imageUrl: url
-        }
       },
     );
   }
 
-  imageNav(url, direction) {
-    let curIndex;
+  imageNav(direction) {
     const lenImages = this.cBuild.images.length;
-
-    for (const image of this.cBuild.images) {
-      if (url === image.url) {
-        curIndex = this.cBuild.images.indexOf(image);
-        break;
-      }
-    }
-    curIndex = (curIndex + direction + lenImages) % lenImages;
-
-    this.windowRef.close();
-    this.openImage(this.cBuild.name, this.cBuild.images[curIndex].url);
+    const currentIndex = this.cBuild.images.indexOf(this.currImage);
+    const nextIndex = (currentIndex + direction + lenImages) % lenImages;
+    this.currImage = this.cBuild.images[nextIndex];
   }
 
   getDiscussionChat() {

--- a/projects/commudle-admin/src/app/feature-modules/community-builds/components/community-build-details/community-build-details.component.ts
+++ b/projects/commudle-admin/src/app/feature-modules/community-builds/components/community-build-details/community-build-details.component.ts
@@ -1,17 +1,17 @@
-import { Component, OnInit, ViewChild, TemplateRef, Input } from '@angular/core';
-import { CommunityBuildsService } from 'projects/commudle-admin/src/app/services/community-builds.service';
+import {Component, Input, OnInit, TemplateRef, ViewChild} from '@angular/core';
 import * as moment from 'moment';
-import { NbWindowService } from '@nebular/theme';
-import { DomSanitizer } from '@angular/platform-browser';
-import { ICommunityBuild, EBuildType, CBuildTypeDisplay } from 'projects/shared-models/community-build.model';
-import { DiscussionsService } from 'projects/commudle-admin/src/app/services/discussions.service';
-import { IDiscussion } from 'projects/shared-models/discussion.model';
+import {NbWindowRef, NbWindowService} from '@nebular/theme';
+import {DomSanitizer} from '@angular/platform-browser';
+import {CBuildTypeDisplay, EBuildType, ICommunityBuild} from 'projects/shared-models/community-build.model';
+import {DiscussionsService} from 'projects/commudle-admin/src/app/services/discussions.service';
+import {IDiscussion} from 'projects/shared-models/discussion.model';
 
 @Component({
   selector: 'app-community-build-details',
   templateUrl: './community-build-details.component.html',
   styleUrls: ['./community-build-details.component.scss']
 })
+
 export class CommunityBuildDetailsComponent implements OnInit {
   @ViewChild('imageTemplate') imageTemplate: TemplateRef<any>;
 
@@ -24,12 +24,14 @@ export class CommunityBuildDetailsComponent implements OnInit {
   CBuildTypeDisplay = CBuildTypeDisplay;
   hasIframe = false;
   embedCode: any;
+  windowRef: NbWindowRef;
 
   constructor(
     private windowService: NbWindowService,
     private discussionsService: DiscussionsService,
     private sanitizer: DomSanitizer
-  ) { }
+  ) {
+  }
 
   ngOnInit() {
     this.getDiscussionChat();
@@ -40,11 +42,11 @@ export class CommunityBuildDetailsComponent implements OnInit {
     }
   }
 
-
   openImage(title, url) {
-    this.windowService.open(
+    this.windowRef = this.windowService.open(
       this.imageTemplate,
-      { title,
+      {
+        title,
         context: {
           imageUrl: url
         }
@@ -52,10 +54,25 @@ export class CommunityBuildDetailsComponent implements OnInit {
     );
   }
 
+  imageNav(url, direction) {
+    let curIndex;
+    const lenImages = this.cBuild.images.length;
+
+    for (const image of this.cBuild.images) {
+      if (url === image.url) {
+        curIndex = this.cBuild.images.indexOf(image);
+        break;
+      }
+    }
+    curIndex = (curIndex + direction + lenImages) % lenImages;
+
+    this.windowRef.close();
+    this.openImage(this.cBuild.name, this.cBuild.images[curIndex].url);
+  }
+
   getDiscussionChat() {
     this.discussionsService.pGetOrCreateForCommunityBuildChat(this.cBuild.id).subscribe(
       data => this.discussionChat = data
     );
   }
-
 }


### PR DESCRIPTION
Added a next and previous button to the images in builds in response to the issue #79 . It also loops around when it reaches the extremes.

How it looks:
![image](https://user-images.githubusercontent.com/60032753/95569528-5334fc00-0a43-11eb-967e-a6a380167c21.png)
