### PR TITLE
Searchbar doesn't close in mozilla firefox browser fix

### DIFF
--- a/projects/commudle-admin/src/app/components/search-bar/search-bar.component.ts
+++ b/projects/commudle-admin/src/app/components/search-bar/search-bar.component.ts
@@ -56,7 +56,8 @@ export class SearchBarComponent implements OnInit, OnDestroy {
 
   toggleSearchSuffix(value: boolean, event?: Event) {
     if (event) {
-      const clickingInSelect = (event as any).path.some((e: HTMLElement) => {
+      var path = (event as any).path || (event.composedPath && event.composedPath());
+      const clickingInSelect = path.some((e: HTMLElement) => {
         return e.classList && e.classList.contains('cdk-overlay-pane');
       });
 

--- a/projects/commudle-admin/src/app/components/search-bar/search-bar.component.ts
+++ b/projects/commudle-admin/src/app/components/search-bar/search-bar.component.ts
@@ -56,7 +56,7 @@ export class SearchBarComponent implements OnInit, OnDestroy {
 
   toggleSearchSuffix(value: boolean, event?: Event) {
     if (event) {
-      var path = (event as any).path || (event.composedPath && event.composedPath());
+      const path = (event as any).path || (event.composedPath && event.composedPath());
       const clickingInSelect = path.some((e: HTMLElement) => {
         return e.classList && e.classList.contains('cdk-overlay-pane');
       });


### PR DESCRIPTION
* Updated a searchbar component function so that closing of searchbar works in firefox browser