### PR TITLE
Override the border-radius of nb-card

### DIFF
--- a/projects/commudle-admin/src/app/components/home/components/home-builds/home-builds.component.scss
+++ b/projects/commudle-admin/src/app/components/home/components/home-builds/home-builds.component.scss
@@ -3,7 +3,6 @@
 .home-builds {
   padding: $space-16;
   border: 0;
-  border-radius: $border-10;
 
   nb-card-header {
     font-size: $fs-h2;

--- a/projects/commudle-admin/src/app/components/home/components/home-communities/home-communities.component.scss
+++ b/projects/commudle-admin/src/app/components/home/components/home-communities/home-communities.component.scss
@@ -2,7 +2,6 @@
 
 .home-communities {
   border: 0;
-  border-radius: $border-10;
 
   nb-card-header {
     font-size: $fs-h2;

--- a/projects/commudle-admin/src/app/components/home/components/home-events/home-events.component.scss
+++ b/projects/commudle-admin/src/app/components/home/components/home-events/home-events.component.scss
@@ -2,7 +2,6 @@
 
 .home-events {
   border: none;
-  border-radius: $border-10;
 
   nb-card-header {
     font-size: $fs-h2;

--- a/projects/commudle-admin/src/app/components/home/components/home-experts/home-experts.component.scss
+++ b/projects/commudle-admin/src/app/components/home/components/home-experts/home-experts.component.scss
@@ -11,7 +11,6 @@ a, a:hover, a:focus, a:active {
 
 .home-experts {
   border: 0;
-  border-radius: $border-10;
 
   nb-card-header {
     font-size: $fs-h2;

--- a/projects/commudle-admin/src/app/components/home/components/home-external-feed-links/home-external-feed-links.component.scss
+++ b/projects/commudle-admin/src/app/components/home/components/home-external-feed-links/home-external-feed-links.component.scss
@@ -2,7 +2,6 @@
 
 .home-external-feed-links {
   border: none;
-  border-radius: $border-10;
 
   nb-card-header {
     font-size: $fs-h2;

--- a/projects/commudle-admin/src/app/components/home/components/home-head-banner/home-head-banner.component.scss
+++ b/projects/commudle-admin/src/app/components/home/components/home-head-banner/home-head-banner.component.scss
@@ -2,7 +2,6 @@
 
 .head-banner {
   border: none;
-  border-radius: $border-10;
 
   p, a, h1 {
     color: $gunmetal;
@@ -35,7 +34,6 @@
       text-decoration: none;
 
       nb-card {
-        border-radius: $border-10;
         margin: 0;
         color: $gunmetal;
 

--- a/projects/commudle-admin/src/app/components/home/components/home-labs/home-labs.component.scss
+++ b/projects/commudle-admin/src/app/components/home/components/home-labs/home-labs.component.scss
@@ -2,7 +2,6 @@
 
 nb-card.home-labs {
   border: none;
-  border-radius: $border-10;
   padding: $space-16;
 
   nb-card-header {

--- a/projects/commudle-admin/src/app/components/home/components/home-promotions/home-promotions.component.scss
+++ b/projects/commudle-admin/src/app/components/home/components/home-promotions/home-promotions.component.scss
@@ -2,7 +2,6 @@
 
 .home-promotions {
   border: none;
-  border-radius: $border-10;
   overflow: hidden;
 
   nb-card-body {

--- a/projects/commudle-admin/src/app/feature-modules/events/components/event-dashboard/event-dashboard.component.scss
+++ b/projects/commudle-admin/src/app/feature-modules/events/components/event-dashboard/event-dashboard.component.scss
@@ -193,7 +193,7 @@
         nb-card-header {
           font-weight: 300;
           font-size: 1rem;
-          padding: 0 0.5rem;
+          padding: 0 1rem;
           color: grey;
         }
       }

--- a/projects/commudle-admin/src/app/feature-modules/external-feed/components/external-feed-hlist-item/external-feed-hlist-item.component.scss
+++ b/projects/commudle-admin/src/app/feature-modules/external-feed/components/external-feed-hlist-item/external-feed-hlist-item.component.scss
@@ -12,7 +12,6 @@
    nb-card {
      margin-bottom: 8px;
      border: $border-1;
-     border-radius: $border-10;
      box-shadow: none;
 
      nb-card-body {

--- a/projects/commudle-admin/src/app/feature-modules/external-feed/components/external-feed/external-feed.component.scss
+++ b/projects/commudle-admin/src/app/feature-modules/external-feed/components/external-feed/external-feed.component.scss
@@ -7,7 +7,6 @@
 
     .tag-checkboxes {
       border: $border-1;
-      border-radius: $border-10;
       box-shadow: none;
 
       font-weight: $fs-h7;
@@ -43,7 +42,6 @@
 
     .header {
       border: $border-1;
-      border-radius: $border-10;
       box-shadow: none;
 
       h1 {
@@ -58,7 +56,6 @@
 
     .sorting {
       border: $border-1;
-      border-radius: $border-10;
       box-shadow: none;
 
       button {

--- a/projects/commudle-admin/src/app/feature-modules/external-feed/components/feed-item-details/feed-item-details.component.scss
+++ b/projects/commudle-admin/src/app/feature-modules/external-feed/components/feed-item-details/feed-item-details.component.scss
@@ -12,7 +12,6 @@
    nb-card {
      margin-bottom: 8px;
      border: $border-1;
-     border-radius: $border-10;
      box-shadow: none;
 
      nb-card-body {

--- a/projects/commudle-admin/src/app/feature-modules/labs/components/lab/lab-details/lab-details.component.scss
+++ b/projects/commudle-admin/src/app/feature-modules/labs/components/lab/lab-details/lab-details.component.scss
@@ -9,7 +9,6 @@
   nb-card {
     width: 100%;
     border: none;
-    border-radius: $border-10;
   }
 
   .user {

--- a/projects/commudle-admin/src/app/feature-modules/labs/components/lab/lab.component.scss
+++ b/projects/commudle-admin/src/app/feature-modules/labs/components/lab/lab.component.scss
@@ -19,7 +19,6 @@
       nb-card {
         min-height: 80vh;
         border: none;
-        border-radius: $border-10;
         margin: 0 $space-16 $space-16;
 
         nb-card-body {

--- a/projects/commudle-admin/src/app/feature-modules/speaker-resources/components/speaker-resource-discussion/speaker-resource-discussion.component.scss
+++ b/projects/commudle-admin/src/app/feature-modules/speaker-resources/components/speaker-resource-discussion/speaker-resource-discussion.component.scss
@@ -2,7 +2,6 @@
 
 .discussion {
   border: none;
-  border-radius: $border-10;
 
   nb-card-header {
     font-size: 1.1rem;

--- a/projects/commudle-admin/src/app/feature-modules/speaker-resources/components/speaker-resource/speaker-resource.component.scss
+++ b/projects/commudle-admin/src/app/feature-modules/speaker-resources/components/speaker-resource/speaker-resource.component.scss
@@ -6,7 +6,6 @@
 
     .user-profile {
       border: none;
-      border-radius: $border-10;
 
       nb-card-body {
         padding: $space-16;
@@ -19,7 +18,6 @@
 
     .details {
       border: none;
-      border-radius: $border-10;
 
       nb-card-body {
         .title {

--- a/projects/commudle-admin/src/app/feature-modules/users/components/public-profile/user-basic-social/user-basic-social.component.scss
+++ b/projects/commudle-admin/src/app/feature-modules/users/components/public-profile/user-basic-social/user-basic-social.component.scss
@@ -3,7 +3,6 @@
 .user-basic-social {
   margin: $space-16 0 0;
   border: none;
-  border-radius: $border-10;
 
   .user-social {
     padding: $space-32 $space-44 $space-40;

--- a/projects/commudle-admin/src/app/feature-modules/users/components/public-profile/user-extra-details/user-badges/user-badges.component.scss
+++ b/projects/commudle-admin/src/app/feature-modules/users/components/public-profile/user-extra-details/user-badges/user-badges.component.scss
@@ -3,7 +3,6 @@
 .user-badges {
   margin: $space-16 0;
   border: none;
-  border-radius: $border-10;
 
   nb-card-body {
     padding: $space-32;

--- a/projects/commudle-admin/src/app/feature-modules/users/components/public-profile/user-extra-details/user-content/user-content.component.scss
+++ b/projects/commudle-admin/src/app/feature-modules/users/components/public-profile/user-extra-details/user-content/user-content.component.scss
@@ -3,7 +3,6 @@
 .user-content {
   nb-card {
     border: none;
-    border-radius: $border-10;
     margin: $space-16 0 0;
 
     nb-card-body {

--- a/projects/commudle-admin/src/themes.scss
+++ b/projects/commudle-admin/src/themes.scss
@@ -1,5 +1,6 @@
 @import '~@nebular/theme/styles/theming';
 @import '~@nebular/theme/styles/themes/default';
+@import '/projects/commudle-admin/src/assets/styles/variables';
 
 $nb-themes: nb-register-theme((
 
@@ -15,4 +16,5 @@ $nb-themes: nb-register-theme((
   // color-primary-900: #091c7a,
   font-family-primary: unquote('Work Sans, sans-serif'),
   font-family-secondary: font-family-primary,
+  card-border-radius: $border-10,
 ), default, default);


### PR DESCRIPTION
* Added border-radius 10px as default for nb-card in themes.scss
*  Removed all the explicitly given 10px border-radius for nb-card elements