### PR TITLE
Feature lazy load images

### DIFF
--- a/projects/commudle-admin/src/app/app.module.ts
+++ b/projects/commudle-admin/src/app/app.module.ts
@@ -89,6 +89,7 @@ import { ReusableComponentsModule } from './feature-modules/reusable-components/
 import { SkeletonScreensModule } from './feature-modules/skeleton-screens/skeleton-screens.module';
 import { UserChatsModule } from './feature-modules/user-chats/user-chats.module';
 import { AppInitService } from './services/app-init.service';
+import { SharedDirectivesModule } from 'projects/shared-directives/shared-directives.module';
 
 export function initApp(appInitService: AppInitService): () => Promise<any> {
   return () => appInitService.initializeApp();
@@ -147,6 +148,7 @@ export function initApp(appInitService: AppInitService): () => Promise<any> {
     SkeletonScreensModule,
     PublicCommunityModule,
     MainNewslettersModule,
+    SharedDirectivesModule,
 
     // external service modules
     LibErrorHandlerModule,

--- a/projects/commudle-admin/src/app/feature-modules/community-builds/community-builds.module.ts
+++ b/projects/commudle-admin/src/app/feature-modules/community-builds/community-builds.module.ts
@@ -13,6 +13,7 @@ import {
 } from '@nebular/theme';
 import { EditorModule } from '@tinymce/tinymce-angular';
 import { SharedComponentsModule } from 'projects/shared-components/shared-components.module';
+import { SharedDirectivesModule } from 'projects/shared-directives/shared-directives.module';
 import { SharedPipesModule } from 'projects/shared-pipes/pipes.module';
 import { CommunityBuildsRoutingModule } from './community-builds-routing.module';
 import { CommunityBuildHListItemComponent } from './components/community-build-h-list-item/community-build-h-list-item.component';
@@ -44,6 +45,7 @@ import { TeammateInviteConfirmationComponent } from './components/teammate-invit
     SharedComponentsModule,
     EditorModule,
     SharedPipesModule,
+    SharedDirectivesModule,
 
     // Nebular
     NbCardModule,

--- a/projects/commudle-admin/src/app/feature-modules/community-control-panel/community-control-panel.module.ts
+++ b/projects/commudle-admin/src/app/feature-modules/community-control-panel/community-control-panel.module.ts
@@ -19,6 +19,7 @@ import { CommunityStatsComponent } from './components/community-stats/community-
 import { CommunityTeamComponent } from './components/community-team/community-team.component';
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
 import { CommunityMembersComponent } from './components/community-members/community-members.component';
+import { SharedDirectivesModule } from 'projects/shared-directives/shared-directives.module';
 
 
 @NgModule({
@@ -45,6 +46,7 @@ import { CommunityMembersComponent } from './components/community-members/commun
     SharedComponentsModule,
     Ng2SmartTableModule,
     FontAwesomeModule,
+    SharedDirectivesModule,
 
     // Nebular
     NbCardModule,

--- a/projects/commudle-admin/src/app/feature-modules/community-groups/community-groups.module.ts
+++ b/projects/commudle-admin/src/app/feature-modules/community-groups/community-groups.module.ts
@@ -8,6 +8,7 @@ import { CommunityGroupsRoutingModule } from './community-groups-routing.module'
 import { CommunityGroupFormComponent } from './components/community-group-form/community-group-form.component';
 import { DashboardComponent } from './components/dashboard/dashboard.component';
 import { SharedComponentsModule } from 'projects/shared-components/shared-components.module';
+import { SharedDirectivesModule } from 'projects/shared-directives/shared-directives.module';
 
 
 @NgModule({
@@ -19,6 +20,7 @@ import { SharedComponentsModule } from 'projects/shared-components/shared-compon
     ReactiveFormsModule,
     EditorModule,
     SharedComponentsModule,
+    SharedDirectivesModule,
 
     // Nebular
     NbCardModule,

--- a/projects/commudle-admin/src/app/feature-modules/email-confirmations/email-confirmations.module.ts
+++ b/projects/commudle-admin/src/app/feature-modules/email-confirmations/email-confirmations.module.ts
@@ -8,6 +8,7 @@ import { UserRoleConfirmationComponent } from './components/user-role-confirmati
 import { NbIconModule, NbCardModule, NbSpinnerModule, NbToggleModule } from '@nebular/theme';
 import { EmailUnsubscribeComponent } from './components/email-unsubscribe/email-unsubscribe.component';
 import { FormsModule } from '@angular/forms';
+import { SharedDirectivesModule } from 'projects/shared-directives/shared-directives.module';
 
 
 @NgModule({
@@ -21,7 +22,7 @@ import { FormsModule } from '@angular/forms';
     CommonModule,
     EmailConfirmationsRoutingModule,
     FormsModule,
-
+    SharedDirectivesModule,
 
 
     // Nebular

--- a/projects/commudle-admin/src/app/feature-modules/labs/labs.module.ts
+++ b/projects/commudle-admin/src/app/feature-modules/labs/labs.module.ts
@@ -20,6 +20,7 @@ import {
 import { EditorModule } from '@tinymce/tinymce-angular';
 import { LinkyModule } from 'ngx-linky';
 import { SharedComponentsModule } from 'projects/shared-components/shared-components.module';
+import { SharedDirectivesModule } from 'projects/shared-directives/shared-directives.module';
 import { SharedPipesModule } from 'projects/shared-pipes/pipes.module';
 import { ReusableComponentsModule } from '../reusable-components/reusable-components.module';
 import { CreateLabComponent } from './components/create-lab/create-lab.component';
@@ -70,6 +71,7 @@ import { LabsRoutingModule } from './labs-routing.module';
     SharedPipesModule,
     NbSpinnerModule,
     LinkyModule,
+    SharedDirectivesModule,
 
     // Nebular
     NbCardModule,

--- a/projects/commudle-admin/src/app/feature-modules/public-community-groups/public-community-groups.module.ts
+++ b/projects/commudle-admin/src/app/feature-modules/public-community-groups/public-community-groups.module.ts
@@ -9,6 +9,7 @@ import { CommunityGroupCommunitiesComponent } from './components/community-group
 import { CommunityGroupTeamComponent } from './components/community-group-team/community-group-team.component';
 import { CommunityGroupAboutComponent } from './components/community-group-about/community-group-about.component';
 import { SharedPipesModule } from 'projects/shared-pipes/pipes.module';
+import { SharedDirectivesModule } from 'projects/shared-directives/shared-directives.module';
 
 
 @NgModule({
@@ -23,6 +24,7 @@ import { SharedPipesModule } from 'projects/shared-pipes/pipes.module';
     PublicCommunityGroupsRoutingModule,
     SharedComponentsModule,
     SharedPipesModule,
+    SharedDirectivesModule,
 
     // Nebular
     NbCardModule,

--- a/projects/commudle-admin/src/app/feature-modules/public-community/public-community.module.ts
+++ b/projects/commudle-admin/src/app/feature-modules/public-community/public-community.module.ts
@@ -17,6 +17,7 @@ import {
   NbTooltipModule
 } from '@nebular/theme';
 import { SharedComponentsModule } from 'projects/shared-components/shared-components.module';
+import { SharedDirectivesModule } from 'projects/shared-directives/shared-directives.module';
 import { SharedPipesModule } from 'projects/shared-pipes/pipes.module';
 import { AboutComponent } from './components/about/about.component';
 import { CommunityChannelsListComponent } from './components/community-channels-list/community-channels-list.component';
@@ -51,6 +52,7 @@ import { PublicCommunityRoutingModule } from './public-community-routing.module'
     ReactiveFormsModule,
     SharedComponentsModule,
     SharedPipesModule,
+    SharedDirectivesModule,
 
     // Nebular
     NbCardModule,

--- a/projects/commudle-admin/src/app/feature-modules/public-events/public-events.module.ts
+++ b/projects/commudle-admin/src/app/feature-modules/public-events/public-events.module.ts
@@ -18,6 +18,7 @@ import {
   NbUserModule,
 } from '@nebular/theme';
 import { SharedComponentsModule } from 'projects/shared-components/shared-components.module';
+import { SharedDirectivesModule } from 'projects/shared-directives/shared-directives.module';
 import { SharedPipesModule } from 'projects/shared-pipes/pipes.module';
 import { AgendaComponent } from './components/agenda/agenda.component';
 import { EventLocationTracksComponent } from './components/agenda/event-location-tracks/event-location-tracks.component';
@@ -75,6 +76,7 @@ import { PublicEventsRoutingModule } from './public-events-routing.module';
     ReactiveFormsModule,
     SharedComponentsModule,
     SharedPipesModule,
+    SharedDirectivesModule,
 
     // Nebular
     NbCardModule,

--- a/projects/commudle-admin/src/app/feature-modules/sys-admin/sys-admin.module.ts
+++ b/projects/commudle-admin/src/app/feature-modules/sys-admin/sys-admin.module.ts
@@ -16,6 +16,7 @@ import {
   NbWindowModule,
 } from '@nebular/theme';
 import { SharedComponentsModule } from 'projects/shared-components/shared-components.module';
+import { SharedDirectivesModule } from 'projects/shared-directives/shared-directives.module';
 import { AdminFeaturedCommunitiesComponent } from './components/admin-featured-communities/admin-featured-communities.component';
 import { AdminPageAdsFormComponent } from './components/admin-page-ads/admin-page-ads-form/admin-page-ads-form.component';
 import { AdminPageAdsListComponent } from './components/admin-page-ads/admin-page-ads-list/admin-page-ads-list.component';
@@ -45,6 +46,7 @@ import { SysAdminComponent } from './sys-admin.component';
     SharedComponentsModule,
     FormsModule,
     ReactiveFormsModule,
+    SharedDirectivesModule,
 
     // Nebular
     NbCardModule,

--- a/projects/commudle-admin/src/app/feature-modules/users/users.module.ts
+++ b/projects/commudle-admin/src/app/feature-modules/users/users.module.ts
@@ -22,6 +22,7 @@ import {
 } from '@nebular/theme';
 import { UserFollowComponent } from 'projects/commudle-admin/src/app/feature-modules/user-follow/user-follow.component';
 import { SharedComponentsModule } from 'projects/shared-components/shared-components.module';
+import { SharedDirectivesModule } from 'projects/shared-directives/shared-directives.module';
 import { SharedPipesModule } from 'projects/shared-pipes/pipes.module';
 import { PublicProfileComponent } from './components/public-profile/public-profile.component';
 import { BasicUserProfileComponent } from './components/public-profile/user-basic-details/basic-user-profile/basic-user-profile.component';
@@ -82,6 +83,7 @@ import { UsersRoutingModule } from './users-routing.module';
     FormsModule,
     SharedComponentsModule,
     DragDropModule,
+    SharedDirectivesModule,
 
     // Nebular
     NbCardModule,

--- a/projects/lib-error-handler/src/lib/lib-error-handler.module.ts
+++ b/projects/lib-error-handler/src/lib/lib-error-handler.module.ts
@@ -3,6 +3,7 @@ import { RouterModule } from '@angular/router';
 import { LibErrorHandlerComponent } from './lib-error-handler.component';
 import { NbToastrModule, NbCardBodyComponent, NbCardModule, NbButtonModule } from '@nebular/theme';
 import { Error404PageComponent } from './components/error404-page/error404-page.component';
+import { SharedDirectivesModule } from 'projects/shared-directives/shared-directives.module';
 
 
 
@@ -12,7 +13,8 @@ import { Error404PageComponent } from './components/error404-page/error404-page.
     RouterModule,
     NbToastrModule.forRoot(),
     NbCardModule,
-    NbButtonModule 
+    NbButtonModule,
+    SharedDirectivesModule 
   ],
   exports: [LibErrorHandlerComponent]
 })

--- a/projects/shared-components/shared-components.module.ts
+++ b/projects/shared-components/shared-components.module.ts
@@ -121,6 +121,7 @@ import { WorkInProgressComponent } from './work-in-progress/work-in-progress.com
     HmsVideoModule,
     PickerModule,
     LinkyModule,
+    SharedDirectivesModule,
 
     // Nebular
     NbButtonModule,

--- a/projects/shared-directives/lazy-load-images.directive.ts
+++ b/projects/shared-directives/lazy-load-images.directive.ts
@@ -1,0 +1,43 @@
+import { Directive, ElementRef, HostBinding, Input, Inject, PLATFORM_ID } from '@angular/core';
+import { isPlatformBrowser } from '@angular/common';
+
+@Directive({
+  selector: 'img'
+})
+export class LazyLoadImagesDirective {
+
+  @HostBinding('attr.src') srcAttr = null;
+  @Input() src: string;
+
+  private isBrowser: boolean = isPlatformBrowser(this.platformId);
+
+  constructor(private el: ElementRef, @Inject(PLATFORM_ID) private platformId: Object) {}
+
+  ngAfterViewInit() {
+    console.log(this.src)
+    if(this.isBrowser){
+      this.canLazyLoad() ? this.lazyLoadImage() : this.loadImage();
+    }
+  }
+
+  private canLazyLoad() {
+    return window && 'IntersectionObserver' in window;
+  }
+
+  private lazyLoadImage() {
+    const obs = new IntersectionObserver(entries => {
+      entries.forEach(({ isIntersecting }) => {
+        if (isIntersecting) {
+          this.loadImage();
+          obs.unobserve(this.el.nativeElement);
+        }
+      });
+    });
+    obs.observe(this.el.nativeElement);
+  }
+
+  private loadImage() {
+    this.srcAttr = this.src;
+  }
+
+}

--- a/projects/shared-directives/lazy-load-images.directive.ts
+++ b/projects/shared-directives/lazy-load-images.directive.ts
@@ -1,17 +1,18 @@
-import { Directive, ElementRef, HostBinding, Input, Inject, PLATFORM_ID } from '@angular/core';
-import { isPlatformBrowser } from '@angular/common';
+import { Directive, ElementRef, HostBinding, Input } from '@angular/core';
+import { IsBrowserService } from 'projects/shared-services/is-browser.service';
 
 @Directive({
-  selector: 'img'
+  selector: 'img',
+  providers: [IsBrowserService]
 })
 export class LazyLoadImagesDirective {
 
   @HostBinding('attr.src') srcAttr = null;
   @Input() src: string;
 
-  private isBrowser: boolean = isPlatformBrowser(this.platformId);
+  private isBrowser: boolean = this.IsBrowserService.isBrowser();
 
-  constructor(private el: ElementRef, @Inject(PLATFORM_ID) private platformId: Object) {}
+  constructor(private el: ElementRef, private IsBrowserService : IsBrowserService) {}
 
   ngAfterViewInit() {
     if(this.isBrowser){

--- a/projects/shared-directives/lazy-load-images.directive.ts
+++ b/projects/shared-directives/lazy-load-images.directive.ts
@@ -14,7 +14,6 @@ export class LazyLoadImagesDirective {
   constructor(private el: ElementRef, @Inject(PLATFORM_ID) private platformId: Object) {}
 
   ngAfterViewInit() {
-    console.log(this.src)
     if(this.isBrowser){
       this.canLazyLoad() ? this.lazyLoadImage() : this.loadImage();
     }

--- a/projects/shared-directives/shared-directives.module.ts
+++ b/projects/shared-directives/shared-directives.module.ts
@@ -1,17 +1,20 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { HighlightLinksDirective } from './highlight-links.directive';
+import { LazyLoadImagesDirective } from './lazy-load-images.directive';
 
 
 @NgModule({
   declarations: [
-    HighlightLinksDirective
+    HighlightLinksDirective,
+    LazyLoadImagesDirective
   ],
   imports: [
     CommonModule
   ],
   exports: [
-    HighlightLinksDirective
+    HighlightLinksDirective,
+    LazyLoadImagesDirective
   ]
 })
 export class SharedDirectivesModule {

--- a/projects/shared-modules/hms-video/hms-video.module.ts
+++ b/projects/shared-modules/hms-video/hms-video.module.ts
@@ -22,6 +22,7 @@ import { SelectRoleComponent } from './components/select-role/select-role.compon
 import { SharedPipesModule } from 'projects/shared-pipes/pipes.module';
 import { IsBrowserService } from 'projects/shared-services/is-browser.service';
 import { HmsClientManagerService } from './services/hms-client-manager.service';
+import { SharedDirectivesModule } from 'projects/shared-directives/shared-directives.module';
 
 
 @NgModule({
@@ -38,6 +39,7 @@ import { HmsClientManagerService } from './services/hms-client-manager.service';
     FormsModule,
     ReactiveFormsModule,
     SharedPipesModule,
+    SharedDirectivesModule,
 
     // Nebular
     NbButtonModule,

--- a/projects/shared-modules/page-ads/page-ads.module.ts
+++ b/projects/shared-modules/page-ads/page-ads.module.ts
@@ -1,11 +1,12 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { NbCardModule } from '@nebular/theme';
+import { SharedDirectivesModule } from 'projects/shared-directives/shared-directives.module';
 import { PageAdsComponent } from './components/page-ads/page-ads.component';
 
 @NgModule({
   declarations: [PageAdsComponent],
-  imports: [CommonModule, NbCardModule],
+  imports: [CommonModule, SharedDirectivesModule, NbCardModule],
   exports: [PageAdsComponent],
 })
 export class PageAdsModule {}


### PR DESCRIPTION
From now on every new module in which components with images are registered needs to have SharedDirectiveModule in the imports for the lazy loading to work.