### PR TITLE
fix: closed channel members list if it is open when clicked on pin msg

### DIFF
--- a/projects/commudle-admin/src/app/feature-modules/community-channels/components/community-channel/community-channel.component.html
+++ b/projects/commudle-admin/src/app/feature-modules/community-channels/components/community-channel/community-channel.component.html
@@ -26,6 +26,7 @@
         [nbPopover]="pinnedMessagesContainer"
         size="lg"
         transform="rotate-45"
+        (click)="closeChannelMembersList()"
       ></fa-icon>
       <nb-actions>
         <nb-action

--- a/projects/commudle-admin/src/app/feature-modules/community-channels/components/community-channel/community-channel.component.scss
+++ b/projects/commudle-admin/src/app/feature-modules/community-channels/components/community-channel/community-channel.component.scss
@@ -91,9 +91,11 @@
     }
 
     .resources {
-      bottom: 65px;
       max-width: 100vw;
       position: relative;
+      right: 0;
+      top: 0;
+      height: 100%;
     }
 
     @media screen and (max-width: 1089px) {

--- a/projects/commudle-admin/src/app/feature-modules/community-channels/components/community-channel/community-channel.component.ts
+++ b/projects/commudle-admin/src/app/feature-modules/community-channels/components/community-channel/community-channel.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnDestroy, OnInit, QueryList, ViewChildren } from '@angular/core';
-import { ActivatedRoute } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 import { CommunityChannelManagerService } from 'projects/commudle-admin/src/app/feature-modules/community-channels/services/community-channel-manager.service';
 import { CommunityChannelNotificationsChannel } from 'projects/commudle-admin/src/app/feature-modules/community-channels/services/websockets/community-channel-notifications.channel';
 import { DiscussionsService } from 'projects/commudle-admin/src/app/services/discussions.service';
@@ -44,6 +44,7 @@ export class CommunityChannelComponent implements OnInit, OnDestroy {
     private communityChannelNotificationsChannel: CommunityChannelNotificationsChannel,
     private communityChannelsService: CommunityChannelsService,
     private communityChannelChannel: CommunityChannelChannel,
+    private router: Router,
   ) {}
 
   ngOnInit() {
@@ -148,6 +149,13 @@ export class CommunityChannelComponent implements OnInit, OnDestroy {
         popover.hide();
       }
     });
+  }
+
+  closeChannelMembersList() {
+    let currentUrl = this.router.url;
+    if (currentUrl.includes('members')) {
+      this.router.navigate([currentUrl.substring(0, currentUrl.lastIndexOf('/'))]);
+    }
   }
 
   initialize() {


### PR DESCRIPTION
Problem : If you open the channel members list and then open pin messages list, it overlaps with the members list.

Fix : closed the members list when opening pin message list.