### PR TITLE
style: fix gap between navbar icons

### DIFF
--- a/apps/commudle-admin/src/app/components/navbar-menu/navbar-menu.component.scss
+++ b/apps/commudle-admin/src/app/components/navbar-menu/navbar-menu.component.scss
@@ -9,7 +9,7 @@ a {
 }
 
 nb-actions {
-  @apply com-h-full com-flex com-gap-x-11 com-justify-evenly com-ml-24;
+  @apply com-h-full com-flex md:com-gap-x-11 com-justify-between md:com-ml-24 md:com-mr-0 com-mx-4;
 
   nb-action {
     @apply com-px-0 com-py-4 md:com-p-0 com-border-none;

--- a/apps/commudle-admin/src/app/components/navbar-menu/navbar-menu.component.ts
+++ b/apps/commudle-admin/src/app/components/navbar-menu/navbar-menu.component.ts
@@ -48,6 +48,7 @@ export class NavbarMenuComponent implements OnInit, OnDestroy {
       externalLink: true,
       target: '_blank',
     },
+    { title: 'Events', link: '/events' },
   ];
 
   subscriptions: Subscription[] = [];


### PR DESCRIPTION
## Type
- (X) Fix
- ( ) Refactor
- ( ) Style
- ( ) Docs
- ( ) Feat
- ( ) Hotfix

## Screenshots
<img width="1434" alt="image" src="https://github.com/commudle/commudle-ng/assets/86765602/bf5e2db8-3d84-4164-bb6b-436f57cedfba">
<img width="676" alt="image" src="https://github.com/commudle/commudle-ng/assets/86765602/9f77bbf8-7c13-4049-9d27-8e60d18423f4">
<img width="1437" alt="image" src="https://github.com/commudle/commudle-ng/assets/86765602/d3b301e5-fa03-4518-b2d1-661ae3580da8">
<img width="801" alt="image" src="https://github.com/commudle/commudle-ng/assets/86765602/a7805283-5e23-4a3e-914a-67717c25fbac">


## Bundle Size
5.17 MB

