### PR TITLE
fix: profile banner image i906

### DIFF
--- a/apps/commudle-admin/src/app/feature-modules/users/components/public-profile/user-extra-details/user-cover-photo/user-cover-photo.component.html
+++ b/apps/commudle-admin/src/app/feature-modules/users/components/public-profile/user-extra-details/user-cover-photo/user-cover-photo.component.html
@@ -2,7 +2,7 @@
   <div class="cover-image">
     <img
       alt="Cover image"
-      src="{{ user.profile_banner_image?.profile_banner || '/assets/images/User-Profile-Cover-Default.png' }}"
+      src="{{ user.profile_banner_image?.i906 || '/assets/images/User-Profile-Cover-Default.png' }}"
     />
   </div>
   <button

--- a/apps/shared-models/attached-file.model.ts
+++ b/apps/shared-models/attached-file.model.ts
@@ -17,4 +17,5 @@ export interface IAttachedFile {
   i160?: string;
   i320?: string;
   i350?: string;
+  i906?: string;
 }


### PR DESCRIPTION
## Type
- (X) Fix
- ( ) Refactor
- ( ) Style
- ( ) Docs
- ( ) Feat
- ( ) Hotfix

## Screenshots
<img width="1000" alt="image" src="https://github.com/commudle/commudle-ng/assets/86765602/69b7d7e2-52bf-43b8-88e3-396ad29c495d">
<img width="964" alt="image" src="https://github.com/commudle/commudle-ng/assets/86765602/385bdf2c-a45b-4d7a-949c-4a56c9604ecc">


## Bundle Size


