### PR TITLE
fix: max-width in banner image

### DIFF
--- a/apps/commudle-admin/src/app/feature-modules/community-builds/components/community-build/community-build-details/community-build-details.component.html
+++ b/apps/commudle-admin/src/app/feature-modules/community-builds/components/community-build/community-build-details/community-build-details.component.html
@@ -97,7 +97,7 @@
         <commudle-banner-image
           [headerImagePath]="this.currImage.url"
           [name]="cBuild.name"
-          [aspectRatio]="'180/127'"
+          [aspectRatio]="'2/1'"
           [topRightCurve]="false"
           [topLeftCurve]="false"
           [bottomRightCurve]="false"

--- a/apps/commudle-admin/src/app/feature-modules/community-builds/components/community-build/community-build-details/community-build-details.component.scss
+++ b/apps/commudle-admin/src/app/feature-modules/community-builds/components/community-build/community-build-details/community-build-details.component.scss
@@ -73,7 +73,7 @@ p {
   nb-card-body {
     @apply md:com-px-6 com-px-4 com-py-4;
     .banner-image {
-      @apply md:com-w-[900px] md:com-h-[635px] com-overflow-y-auto com-w-full com-h-auto com-scrollbar-hide;
+      @apply md:com-w-[900px] com-overflow-y-auto com-w-full com-h-auto com-scrollbar-hide;
     }
 
     .controls {

--- a/apps/shared-components/banner-image/banner-image.component.scss
+++ b/apps/shared-components/banner-image/banner-image.component.scss
@@ -25,7 +25,7 @@
     .image-section {
       @apply com-flex com-justify-center;
       img {
-        @apply com-h-full com-max-w-full com-absolute com-top-0;
+        @apply com-h-full com-max-w-full com-absolute com-top-0 com-object-contain;
       }
     }
   }

--- a/apps/shared-components/banner-image/banner-image.component.scss
+++ b/apps/shared-components/banner-image/banner-image.component.scss
@@ -25,7 +25,7 @@
     .image-section {
       @apply com-flex com-justify-center;
       img {
-        @apply com-h-full com-absolute com-top-0;
+        @apply com-h-full com-max-w-full com-absolute com-top-0;
       }
     }
   }


### PR DESCRIPTION
# PR Template

## Type

- (X) Fix
- ( ) Refactor
- ( ) Style
- ( ) Docs
- ( ) Feat
- ( ) Hotfix

## description

## Screenshots

<img width="1512" alt="image" src="https://github.com/commudle/commudle-ng/assets/86765602/80797624-d21d-4dd8-acc2-4c0ebed1d04f">
<img width="1452" alt="image" src="https://github.com/commudle/commudle-ng/assets/86765602/ddb6efa7-5329-4ade-89ad-396d68b6a53b">
<img width="870" alt="image" src="https://github.com/commudle/commudle-ng/assets/86765602/a1fcb72c-2388-484c-93ad-fe8aaa78079d">


## Bundle Size
