### PR TITLE
feat: add acceptance_mail_sent in hackathon team acceptance

### DIFF
--- a/apps/commudle-admin/src/app/feature-modules/hackathon-control-panel/components/hackathon-control-panel-review/hackathon-control-panel-review.component.html
+++ b/apps/commudle-admin/src/app/feature-modules/hackathon-control-panel/components/hackathon-control-panel-review/hackathon-control-panel-review.component.html
@@ -161,7 +161,7 @@
             fullWidth
             (click)="generateTeamRegistrationStatusNotification(selectedTeamDetails.id)"
           >
-            Send Acceptance Email
+            {{ selectedTeamDetails.acceptance_mail_sent ? 'resend Acceptance Email' : 'Send Acceptance Email' }}
           </button>
           <button
             nbButton

--- a/apps/commudle-admin/src/app/feature-modules/hackathon-control-panel/components/hackathon-control-panel-review/hackathon-control-panel-review.component.ts
+++ b/apps/commudle-admin/src/app/feature-modules/hackathon-control-panel/components/hackathon-control-panel-review/hackathon-control-panel-review.component.ts
@@ -172,6 +172,7 @@ export class HackathonControlPanelReviewComponent implements OnInit, OnDestroy {
   generateTeamRegistrationStatusNotification(teamId) {
     this.hackathonService.generateTeamRegistrationStatusNotification(teamId).subscribe((data) => {
       if (data) {
+        this.selectedTeamDetails.acceptance_mail_sent = true;
         this.toastrService.successDialog('Emails are being delivered!');
       }
     });

--- a/libs/shared/models/src/lib/hackathon-team.model.ts
+++ b/libs/shared/models/src/lib/hackathon-team.model.ts
@@ -16,6 +16,7 @@ export interface IHackathonTeam {
   notes: INote[];
   hackathon_winners: IHackathonWinner[];
   hackathon_id: number;
+  acceptance_mail_sent: boolean;
   prize_selected: boolean; //use for display only not related to API requests
 }
 


### PR DESCRIPTION
# PR Template

## Type

- ( ) Fix
- ( ) Refactor
- ( ) Style
- ( ) Docs
- (X) Feat
- ( ) Hotfix

## description
Add acceptance_mail_sent after acceptance mail send and also mark as true in an BE

## Screenshots

## Bundle Size
