### PR TITLE
fix: form fill text in public event page

### DIFF
--- a/apps/commudle-admin/src/app/feature-modules/public-events/components/highlighted-links/highlighted-links.component.html
+++ b/apps/commudle-admin/src/app/feature-modules/public-events/components/highlighted-links/highlighted-links.component.html
@@ -22,7 +22,7 @@
           icon="bulb"
         ></nb-icon>
         <nb-icon *ngIf="form.already_filled" class="edit-icon" icon="edit"></nb-icon>
-        {{ form.name }}
+        <span> {{ form.name }}</span>
       </a>
     </div>
   </div>

--- a/apps/commudle-admin/src/app/feature-modules/public-events/components/highlighted-links/highlighted-links.component.scss
+++ b/apps/commudle-admin/src/app/feature-modules/public-events/components/highlighted-links/highlighted-links.component.scss
@@ -16,6 +16,9 @@
 
     a {
       @apply com-w-full com-overflow-hidden;
+      span {
+        @apply com-truncate;
+      }
     }
 
     @media screen and (min-width: 800px) {


### PR DESCRIPTION
# PR Template

## Type

- (X) Fix
- ( ) Refactor
- ( ) Style
- ( ) Docs
- ( ) Feat
- ( ) Hotfix

## description
Make text truncate in button for form fill links in public side event page

## Screenshots
![image](https://github.com/user-attachments/assets/0f38ec88-b236-4d02-889a-f2d5729c274d)


## Bundle Size
