### PR TITLE
fix: add default image URL binding for campaign assets display across components

### DIFF
--- a/apps/commudle-admin/src/app/components/sidebar-menu/sidebar-menu.component.html
+++ b/apps/commudle-admin/src/app/components/sidebar-menu/sidebar-menu.component.html
@@ -28,13 +28,13 @@
       </a>
     </nb-list-item>
 
-    <nb-list-item *ngIf="currentUser" class="disable">
-      <a>
+    <nb-list-item *ngIf="currentUser">
+      <a [routerLink]="['campaigns']">
         <fa-icon [icon]="faRectangleAd"></fa-icon>
         <div>
           <span>My Ad Campaigns</span>
           <br />
-          <small>(Coming Soon!)</small>
+          <small>(Beta)</small>
         </div>
       </a>
     </nb-list-item>

--- a/apps/commudle-admin/src/app/feature-modules/admin-campaign/components/campaign-form/campaign-form-order-confirmation/campaign-form-order-confirmation.component.html
+++ b/apps/commudle-admin/src/app/feature-modules/admin-campaign/components/campaign-form/campaign-form-order-confirmation/campaign-form-order-confirmation.component.html
@@ -42,14 +42,19 @@
       </div>
     </nb-card-body>
   </nb-card>
-  <commudle-alert
-    [info]="true"
-    message="All ads are subject to approval from our team. In case of any changes needed or rejection, you will be notified by email"
-  ></commudle-alert>
+  <commudle-alert [info]="true">
+    <div infoContent>
+      All ads are subject to approval from our team. In case of any changes needed or rejection, you will be notified by
+      email. For any queries please write to
+      <a href="mailto:campaigns_support@commudle.com">campaigns_support&#64;commudle.com</a>
+    </div>
+  </commudle-alert>
   <br />
   <nb-checkbox [(ngModel)]="consent" status="basic">
-    By submitting this ad for approval you confirm that you have read our privacy policy and terms & conditions. You
-    also understand that all the information provided here is correct and does not pose any harm to anyone who visits
+    By submitting this ad for approval you confirm that you have read our
+    <a href="https://www.commudle.com/policies/privacy-policy" target="_blank">privacy policy</a> and
+    <a href="https://www.commudle.com/policies/terms-and-conditions" target="_blank">terms & conditions.</a> You also
+    understand that all the information provided here is correct and does not pose any harm to anyone who visits
     Commudle.
   </nb-checkbox>
 

--- a/apps/commudle-admin/src/app/feature-modules/admin-campaign/components/campaign-form/campaign-form-select-campaign/campaign-form-select-campaign.component.html
+++ b/apps/commudle-admin/src/app/feature-modules/admin-campaign/components/campaign-form/campaign-form-select-campaign/campaign-form-select-campaign.component.html
@@ -2,6 +2,18 @@
   <div class="text">
     <p class="header">Welcome to Commudle’s Self-Serve Advertising Portal</p>
     <p class="sub-heading">This is where you can set up a campaign instantly, all on your own.</p>
+    <div class="info">
+      <commudle-alert [info]="true" message=" This feature is in beta"></commudle-alert>
+      <br />
+      <commudle-alert [info]="true">
+        <div infoContent>
+          Read here about how ad campaigns work
+          <a href="https://www.commudle.com/policies/self-serve-advertising-portal" target="_blank">
+            https://www.commudle.com/policies/self-serve-advertising-portal</a
+          >
+        </div>
+      </commudle-alert>
+    </div>
     <p class="header">Why advertise on Commudle?</p>
     <p class="sub-heading">
       Commudle is the fastest-growing professional network for developers worldwide. When you advertise with our in-feed

--- a/apps/commudle-admin/src/app/feature-modules/admin-campaign/components/campaign-form/campaign-form-select-campaign/campaign-form-select-campaign.component.html
+++ b/apps/commudle-admin/src/app/feature-modules/admin-campaign/components/campaign-form/campaign-form-select-campaign/campaign-form-select-campaign.component.html
@@ -21,6 +21,10 @@
     </p>
   </div>
 
+  <commudle-alert [info]="true">
+    <div infoContent>Select campaign type carefully, it cannot be edited once you move to the next step.</div>
+  </commudle-alert>
+
   <commudle-loading-spinner *ngIf="isLoading"></commudle-loading-spinner>
   <nb-card *ngIf="!isLoading">
     <nb-card-header>Select one of the following</nb-card-header>

--- a/apps/commudle-admin/src/app/feature-modules/admin-campaign/components/campaign-form/campaign-form-select-campaign/campaign-form-select-campaign.component.html
+++ b/apps/commudle-admin/src/app/feature-modules/admin-campaign/components/campaign-form/campaign-form-select-campaign/campaign-form-select-campaign.component.html
@@ -38,7 +38,7 @@
             <p class="header">{{ campaignType.name }}</p>
             <p class="clamped-description">
               <span [innerHTML]="getClampedText(campaignType.description)"></span>&nbsp;
-              <ng-container *ngIf="campaignType.description.length > 100">
+              <ng-container *ngIf="campaignType.description.length > 150">
                 <a (click)="viewMoreClicked(formTypeDescription, campaignType); $event.stopPropagation()">View More</a>
               </ng-container>
             </p>

--- a/apps/commudle-admin/src/app/feature-modules/admin-campaign/components/campaign-form/campaign-form-select-campaign/campaign-form-select-campaign.component.ts
+++ b/apps/commudle-admin/src/app/feature-modules/admin-campaign/components/campaign-form/campaign-form-select-campaign/campaign-form-select-campaign.component.ts
@@ -69,7 +69,7 @@ export class CampaignFormSelectCampaignComponent implements OnInit {
   }
 
   getClampedText(description: string): string {
-    const limit = 100;
+    const limit = 150;
     if (description.length > limit) {
       return description.slice(0, limit) + '...';
     }

--- a/apps/commudle-admin/src/app/feature-modules/notifications/components/user-notifications-campaign/user-notifications-campaign.component.html
+++ b/apps/commudle-admin/src/app/feature-modules/notifications/components/user-notifications-campaign/user-notifications-campaign.component.html
@@ -1,5 +1,6 @@
 <div>
   <commudle-campaign-assets-display
+    [defaultImageUrl]="defaultUrl"
     [defaultImage]="staticAssets.campaign_user_notification_default"
     [campaignTypeSlug]="ECampaignTypeSlug.USER_NOTIFICATION_RIGHT_SIDEBAR_IMAGE"
   ></commudle-campaign-assets-display>

--- a/apps/commudle-admin/src/app/feature-modules/notifications/components/user-notifications-campaign/user-notifications-campaign.component.ts
+++ b/apps/commudle-admin/src/app/feature-modules/notifications/components/user-notifications-campaign/user-notifications-campaign.component.ts
@@ -1,4 +1,5 @@
 import { Component } from '@angular/core';
+import { environment } from '@commudle/shared-environments';
 import { ECampaignTypeSlug } from '@commudle/shared-models';
 import { staticAssets } from 'apps/commudle-admin/src/assets/static-assets';
 @Component({
@@ -9,4 +10,5 @@ import { staticAssets } from 'apps/commudle-admin/src/assets/static-assets';
 export class UserNotificationsCampaignComponent {
   staticAssets = staticAssets;
   ECampaignTypeSlug = ECampaignTypeSlug;
+  defaultUrl = environment.app_url + '/campaigns/new';
 }

--- a/apps/commudle-admin/src/app/feature-modules/search/components/search-page-campaign/search-page-campaign.component.html
+++ b/apps/commudle-admin/src/app/feature-modules/search/components/search-page-campaign/search-page-campaign.component.html
@@ -1,5 +1,6 @@
 <div>
   <commudle-campaign-assets-display
+    [defaultImageUrl]="defaultUrl"
     [defaultImage]="staticAssets.campaign_main_search_page_default"
     [campaignTypeSlug]="ECampaignTypeSlug.MAIN_SEARCH_PAGE_RIGHT_SIDEBAR_IMAGE"
   ></commudle-campaign-assets-display>

--- a/apps/commudle-admin/src/app/feature-modules/search/components/search-page-campaign/search-page-campaign.component.ts
+++ b/apps/commudle-admin/src/app/feature-modules/search/components/search-page-campaign/search-page-campaign.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 import { ECampaignTypeSlug } from '@commudle/shared-models';
 import { staticAssets } from 'apps/commudle-admin/src/assets/static-assets';
-
+import { environment } from '@commudle/shared-environments';
 @Component({
   selector: 'commudle-search-page-campaign',
   templateUrl: './search-page-campaign.component.html',
@@ -10,4 +10,6 @@ import { staticAssets } from 'apps/commudle-admin/src/assets/static-assets';
 export class SearchPageCampaignComponent {
   staticAssets = staticAssets;
   ECampaignTypeSlug = ECampaignTypeSlug;
+
+  defaultUrl = environment.app_url + '/campaigns/new';
 }

--- a/apps/commudle-admin/src/app/feature-modules/users/components/public-profile/public-profile-campaign/public-profile-campaign.component.html
+++ b/apps/commudle-admin/src/app/feature-modules/users/components/public-profile/public-profile-campaign/public-profile-campaign.component.html
@@ -1,5 +1,6 @@
 <div>
   <commudle-campaign-assets-display
+    [defaultImageUrl]="defaultUrl"
     [defaultImage]="staticAssets.campaign_user_profile_default"
     [campaignTypeSlug]="ECampaignTypeSlug.USER_PROFILE_RIGHT_SIDEBAR_IMAGE"
   ></commudle-campaign-assets-display>

--- a/apps/commudle-admin/src/app/feature-modules/users/components/public-profile/public-profile-campaign/public-profile-campaign.component.ts
+++ b/apps/commudle-admin/src/app/feature-modules/users/components/public-profile/public-profile-campaign/public-profile-campaign.component.ts
@@ -1,4 +1,5 @@
 import { Component } from '@angular/core';
+import { environment } from '@commudle/shared-environments';
 import { ECampaignTypeSlug } from '@commudle/shared-models';
 import { staticAssets } from 'apps/commudle-admin/src/assets/static-assets';
 
@@ -10,4 +11,5 @@ import { staticAssets } from 'apps/commudle-admin/src/assets/static-assets';
 export class PublicProfileCampaignComponent {
   ECampaignTypeSlug = ECampaignTypeSlug;
   staticAssets = staticAssets;
+  defaultUrl = environment.app_url + '/campaigns/new';
 }

--- a/apps/shared-components/campaign-list/campaign-list.component.html
+++ b/apps/shared-components/campaign-list/campaign-list.component.html
@@ -178,7 +178,7 @@
           nbButton
           status="danger"
           size="small"
-          (click)="$event.stopPropagation(); destroy(campaign.id)"
+          (click)="$event.stopPropagation(); openDestroyCampaignPopup(destroyCampaign, campaign)"
         >
           Destroy
         </button>
@@ -220,6 +220,29 @@
         Update
       </button>
       <button nbButton status="danger" (click)="ref.close()">Close</button>
+    </nb-card-footer>
+  </nb-card>
+</ng-template>
+
+<ng-template #destroyCampaign let-data let-ref="dialogRef">
+  <nb-card class="destroy-campaign">
+    <nb-card-header>
+      <div>
+        Are you sure ?
+        {{ data.campaign.name }}
+      </div>
+      <button ghost nbButton size="small" (click)="ref.close()" shape="round">
+        <nb-icon icon="close"></nb-icon>
+      </button>
+    </nb-card-header>
+    <nb-card-body>
+      <p>
+        You want to destroy <strong>{{ data.campaign.name }}</strong>
+      </p>
+    </nb-card-body>
+    <nb-card-footer>
+      <button nbButton status="danger" (click)="destroy(data.campaign.id); ref.close()">Destroy</button>
+      <button nbButton status="info" (click)="ref.close()">Close</button>
     </nb-card-footer>
   </nb-card>
 </ng-template>

--- a/apps/shared-components/campaign-list/campaign-list.component.scss
+++ b/apps/shared-components/campaign-list/campaign-list.component.scss
@@ -51,7 +51,8 @@
   }
 }
 
-.update-newsletter {
+.update-newsletter,
+.destroy-campaign {
   @apply com-w-full md:com-w-[20dvw];
   nb-card-header,
   nb-card-footer {

--- a/apps/shared-components/campaign-list/campaign-list.component.ts
+++ b/apps/shared-components/campaign-list/campaign-list.component.ts
@@ -26,7 +26,7 @@ export class CampaignListComponent {
 
   EPurchaseOrderStatus = EPurchaseOrderStatus;
   noteTexts: { [campaignId: number]: string } = {};
-  newsletterId: number;
+  newsletterId: number | null;
   constructor(
     private campaignService: CampaignService,
     private toasterService: ToastrService,
@@ -53,6 +53,10 @@ export class CampaignListComponent {
       }
       this.dialogService.open(dialog, { context: { campaignId: campaign.id } });
     }
+  }
+
+  openDestroyCampaignPopup(dialog, campaign) {
+    this.dialogService.open(dialog, { context: { campaign: campaign } });
   }
 
   updateNotes(campaignId: number) {


### PR DESCRIPTION
# PR Template

## Type

- (X) Fix
- (X) Refactor
- (X) Style
- ( ) Docs
- (X) Feat
- ( ) Hotfix
- ( ) Merge

## Description

## Screenshots
![image](https://github.com/user-attachments/assets/43d644f9-ef14-493c-b543-4f2ee0a8f26a)

![image](https://github.com/user-attachments/assets/64e4464d-908d-44a2-bd09-5d92f20f7d68)

![image](https://github.com/user-attachments/assets/76f4e0c5-8bc0-40ee-a592-e5069aa5fb53)

![image](https://github.com/user-attachments/assets/6ff067f1-637a-41c9-ab45-1b3dc0c563ad)

## Testing

## Bundle Size