### PR TITLE
fix(event-list): redirect to stats page if event is completed

### DIFF
--- a/apps/commudle-admin/src/app/feature-modules/community-control-panel/components/community-events-list/community-events-list-actions/community-events-list-actions.component.html
+++ b/apps/commudle-admin/src/app/feature-modules/community-control-panel/components/community-events-list/community-events-list-actions/community-events-list-actions.component.html
@@ -3,6 +3,8 @@
     [routerLink]="
       eventData.status === EEventStatuses.OPEN
         ? ['event-dashboard', eventData.slug, 'registrations']
+        : eventData.status === EEventStatuses.COMPLETED
+        ? ['event-dashboard', eventData.slug, 'stats']
         : ['event-dashboard', eventData.slug]
     "
     nbButton


### PR DESCRIPTION
# PR Template

## Type

- (X) Fix
- ( ) Refactor
- ( ) Style
- ( ) Docs
- ( ) Feat
- ( ) Hotfix
- ( ) Merge

## Description
If event status is "COMPLETED", the page redirects to stats when clicked on dashboard

## Screenshots
<img width="943" alt="image" src="https://github.com/user-attachments/assets/e52005ea-6ebf-4c22-9242-2d5d74e3c235" />


## Testing

## Bundle Size