### PR TITLE
Refactor(newsletter): add preview button

### DIFF
--- a/apps/commudle-admin/src/app/app-shared-components/newsletter/newsletter-form/newsletter-form.component.html
+++ b/apps/commudle-admin/src/app/app-shared-components/newsletter/newsletter-form/newsletter-form.component.html
@@ -146,6 +146,7 @@
       >
         Save & Send Test Emails
       </button>
+      <button nbButton status="primary" (click)="redirectTo(pageSlug)">Preview Newsletter</button>
     </div>
     <div class="back-button" (click)="backPage()">
       <fa-icon [icon]="icons.faChevronLeft" class="com-mr-1"></fa-icon> Back to list of newsletter

--- a/apps/commudle-admin/src/app/app-shared-components/newsletter/newsletter-form/newsletter-form.component.html
+++ b/apps/commudle-admin/src/app/app-shared-components/newsletter/newsletter-form/newsletter-form.component.html
@@ -146,7 +146,22 @@
       >
         Save & Send Test Emails
       </button>
-      <button nbButton status="primary" (click)="redirectTo()">Preview Newsletter</button>
+      <a
+        *ngIf="parentType === 'Kommunity'"
+        [routerLink]="['/communities', parentId, 'newsletters', pageSlug]"
+        nbButton
+        status="primary"
+      >
+        Preview Newsletter
+      </a>
+      <a
+        *ngIf="parentType === 'CommunityGroup'"
+        [routerLink]="['/orgs', parentId, 'newsletters', pageSlug]"
+        nbButton
+        status="primary"
+      >
+        Preview Newsletter
+      </a>
     </div>
     <div class="back-button" (click)="backPage()">
       <fa-icon [icon]="icons.faChevronLeft" class="com-mr-1"></fa-icon> Back to list of newsletter

--- a/apps/commudle-admin/src/app/app-shared-components/newsletter/newsletter-form/newsletter-form.component.html
+++ b/apps/commudle-admin/src/app/app-shared-components/newsletter/newsletter-form/newsletter-form.component.html
@@ -147,16 +147,12 @@
         Save & Send Test Emails
       </button>
       <a
-        *ngIf="parentType === 'Kommunity'"
-        [routerLink]="['/communities', parentId, 'newsletters', pageSlug]"
-        nbButton
-        status="primary"
-      >
-        Preview Newsletter
-      </a>
-      <a
-        *ngIf="parentType === 'CommunityGroup'"
-        [routerLink]="['/orgs', parentId, 'newsletters', pageSlug]"
+        *ngIf="parentType === 'Kommunity' || parentType === 'CommunityGroup'"
+        [routerLink]="
+          parentType === 'Kommunity'
+            ? ['/communities', parentId, 'newsletters', pageSlug]
+            : ['/orgs', parentId, 'newsletters', pageSlug]
+        "
         nbButton
         status="primary"
       >

--- a/apps/commudle-admin/src/app/app-shared-components/newsletter/newsletter-form/newsletter-form.component.html
+++ b/apps/commudle-admin/src/app/app-shared-components/newsletter/newsletter-form/newsletter-form.component.html
@@ -157,7 +157,7 @@
         status="primary"
       >
         Preview Newsletter
-        <nb-icon icon="external-link" class="com-text-base ml-2"></nb-icon>
+        <nb-icon icon="external-link"></nb-icon>
       </a>
     </div>
     <div class="back-button" (click)="backPage()">

--- a/apps/commudle-admin/src/app/app-shared-components/newsletter/newsletter-form/newsletter-form.component.html
+++ b/apps/commudle-admin/src/app/app-shared-components/newsletter/newsletter-form/newsletter-form.component.html
@@ -147,11 +147,12 @@
         Save & Send Test Emails
       </button>
       <a
-        *ngIf="parentType === 'Kommunity' || parentType === 'CommunityGroup'"
         [routerLink]="
-          parentType === 'Kommunity'
+          parentType === EDbModels.KOMMUNITY
             ? ['/communities', parentId, 'newsletters', pageSlug]
-            : ['/orgs', parentId, 'newsletters', pageSlug]
+            : parentType === EDbModels.COMMUNITY_GROUP
+            ? ['/orgs', parentId, 'newsletters', pageSlug]
+            : []
         "
         nbButton
         status="primary"

--- a/apps/commudle-admin/src/app/app-shared-components/newsletter/newsletter-form/newsletter-form.component.html
+++ b/apps/commudle-admin/src/app/app-shared-components/newsletter/newsletter-form/newsletter-form.component.html
@@ -146,7 +146,7 @@
       >
         Save & Send Test Emails
       </button>
-      <button nbButton status="primary" (click)="redirectTo(pageSlug)">Preview Newsletter</button>
+      <button nbButton status="primary" (click)="redirectTo()">Preview Newsletter</button>
     </div>
     <div class="back-button" (click)="backPage()">
       <fa-icon [icon]="icons.faChevronLeft" class="com-mr-1"></fa-icon> Back to list of newsletter

--- a/apps/commudle-admin/src/app/app-shared-components/newsletter/newsletter-form/newsletter-form.component.html
+++ b/apps/commudle-admin/src/app/app-shared-components/newsletter/newsletter-form/newsletter-form.component.html
@@ -146,17 +146,10 @@
       >
         Save & Send Test Emails
       </button>
-      <a
-        [routerLink]="
-          parentType === EDbModels.KOMMUNITY
-            ? ['/communities', parentId, 'newsletters', pageSlug]
-            : ['/orgs', parentId, 'newsletters', pageSlug]
-        "
-        nbButton
-        status="primary"
-      >
+      <button nbButton status="primary" (click)="redirectTo()">
         Preview Newsletter
-      </a>
+        <nb-icon icon="external-link" class="com-text-base ml-2"></nb-icon>
+      </button>
     </div>
     <div class="back-button" (click)="backPage()">
       <fa-icon [icon]="icons.faChevronLeft" class="com-mr-1"></fa-icon> Back to list of newsletter

--- a/apps/commudle-admin/src/app/app-shared-components/newsletter/newsletter-form/newsletter-form.component.html
+++ b/apps/commudle-admin/src/app/app-shared-components/newsletter/newsletter-form/newsletter-form.component.html
@@ -147,7 +147,7 @@
         Save & Send Test Emails
       </button>
       <a
-        [href]="
+        [routerLink]="
           parentType === EDbModels.KOMMUNITY
             ? '/communities/' + parentId + '/newsletters/' + pageSlug
             : '/orgs/' + parentId + '/newsletters/' + pageSlug

--- a/apps/commudle-admin/src/app/app-shared-components/newsletter/newsletter-form/newsletter-form.component.html
+++ b/apps/commudle-admin/src/app/app-shared-components/newsletter/newsletter-form/newsletter-form.component.html
@@ -150,9 +150,7 @@
         [routerLink]="
           parentType === EDbModels.KOMMUNITY
             ? ['/communities', parentId, 'newsletters', pageSlug]
-            : parentType === EDbModels.COMMUNITY_GROUP
-            ? ['/orgs', parentId, 'newsletters', pageSlug]
-            : []
+            : ['/orgs', parentId, 'newsletters', pageSlug]
         "
         nbButton
         status="primary"

--- a/apps/commudle-admin/src/app/app-shared-components/newsletter/newsletter-form/newsletter-form.component.html
+++ b/apps/commudle-admin/src/app/app-shared-components/newsletter/newsletter-form/newsletter-form.component.html
@@ -150,9 +150,7 @@
         [href]="
           parentType === EDbModels.KOMMUNITY
             ? '/communities/' + parentId + '/newsletters/' + pageSlug
-            : parentType === EDbModels.COMMUNITY_GROUP
-            ? '/orgs/' + parentId + '/newsletters/' + pageSlug
-            : null
+            : '/orgs/' + parentId + '/newsletters/' + pageSlug
         "
         target="_blank"
         nbButton

--- a/apps/commudle-admin/src/app/app-shared-components/newsletter/newsletter-form/newsletter-form.component.html
+++ b/apps/commudle-admin/src/app/app-shared-components/newsletter/newsletter-form/newsletter-form.component.html
@@ -146,10 +146,21 @@
       >
         Save & Send Test Emails
       </button>
-      <button nbButton status="primary" (click)="redirectTo()">
+      <a
+        [href]="
+          parentType === EDbModels.KOMMUNITY
+            ? '/communities/' + parentId + '/newsletters/' + pageSlug
+            : parentType === EDbModels.COMMUNITY_GROUP
+            ? '/orgs/' + parentId + '/newsletters/' + pageSlug
+            : null
+        "
+        target="_blank"
+        nbButton
+        status="primary"
+      >
         Preview Newsletter
         <nb-icon icon="external-link" class="com-text-base ml-2"></nb-icon>
-      </button>
+      </a>
     </div>
     <div class="back-button" (click)="backPage()">
       <fa-icon [icon]="icons.faChevronLeft" class="com-mr-1"></fa-icon> Back to list of newsletter

--- a/apps/commudle-admin/src/app/app-shared-components/newsletter/newsletter-form/newsletter-form.component.ts
+++ b/apps/commudle-admin/src/app/app-shared-components/newsletter/newsletter-form/newsletter-form.component.ts
@@ -156,13 +156,14 @@ export class NewsletterFormComponent implements OnInit, AfterViewInit {
       }),
     );
   }
-  redirectTo(slug) {
+
+  redirectTo() {
     let pathSegments: string[] = [];
 
     if (this.parentType === 'Kommunity') {
-      pathSegments = ['communities', String(this.parentId), 'newsletters', slug];
+      pathSegments = ['communities', String(this.parentId), 'newsletters', this.pageSlug];
     } else if (this.parentType === 'CommunityGroup') {
-      pathSegments = ['orgs', String(this.parentId), 'newsletters', slug];
+      pathSegments = ['orgs', String(this.parentId), 'newsletters', this.pageSlug];
     }
 
     this.router.navigate(pathSegments);

--- a/apps/commudle-admin/src/app/app-shared-components/newsletter/newsletter-form/newsletter-form.component.ts
+++ b/apps/commudle-admin/src/app/app-shared-components/newsletter/newsletter-form/newsletter-form.component.ts
@@ -10,6 +10,7 @@ import { faChevronLeft, faFileImage } from '@fortawesome/free-solid-svg-icons';
 import grapesjs from 'grapesjs';
 import plugin from 'grapesjs-preset-newsletter';
 import { NbDialogService } from '@commudle/theme';
+import { Router } from '@angular/router';
 
 @Component({
   selector: 'commudle-newsletter-form',
@@ -79,6 +80,7 @@ export class NewsletterFormComponent implements OnInit, AfterViewInit {
     private location: Location,
     private toastrService: ToastrService,
     private dialogService: NbDialogService,
+    private router: Router,
   ) {
     this.newsletterForm = this.fb.group({
       title: ['', Validators.required],
@@ -153,6 +155,17 @@ export class NewsletterFormComponent implements OnInit, AfterViewInit {
         }
       }),
     );
+  }
+  redirectTo(slug) {
+    let pathSegments: string[] = [];
+
+    if (this.parentType === 'Kommunity') {
+      pathSegments = ['communities', String(this.parentId), 'newsletters', slug];
+    } else if (this.parentType === 'CommunityGroup') {
+      pathSegments = ['orgs', String(this.parentId), 'newsletters', slug];
+    }
+
+    this.router.navigate(pathSegments);
   }
 
   initEditor() {

--- a/apps/commudle-admin/src/app/app-shared-components/newsletter/newsletter-form/newsletter-form.component.ts
+++ b/apps/commudle-admin/src/app/app-shared-components/newsletter/newsletter-form/newsletter-form.component.ts
@@ -388,16 +388,6 @@ export class NewsletterFormComponent implements OnInit, AfterViewInit {
       }, 500);
     }
   }
-  redirectTo() {
-    let Url = '';
-
-    if (this.parentType === EDbModels.KOMMUNITY) {
-      Url = '/communities/' + this.parentId + '/newsletters/' + this.pageSlug;
-    } else if (this.parentType === EDbModels.COMMUNITY_GROUP) {
-      Url = '/orgs/' + this.parentId + '/newsletters/' + this.pageSlug;
-    }
-    window.open(Url, '_blank');
-  }
   getDefaultTemplate(): string {
     this.defaultTemplate = `<body style="box-sizing: border-box; margin: 0; margin-top: 0px; margin-right: 0px; margin-bottom: 0px; margin-left: 0px;">
   <table id="i0066" style="box-sizing: border-box; height: 40px; margin-top: 0px; margin-right: auto; margin-bottom: 10px; margin-left: auto; padding-top: 5px; padding-right: 5px; padding-bottom: 5px; padding-left: 5px; width: 100%;" width="100%" height="40">

--- a/apps/commudle-admin/src/app/app-shared-components/newsletter/newsletter-form/newsletter-form.component.ts
+++ b/apps/commudle-admin/src/app/app-shared-components/newsletter/newsletter-form/newsletter-form.component.ts
@@ -10,6 +10,7 @@ import { faChevronLeft, faFileImage } from '@fortawesome/free-solid-svg-icons';
 import grapesjs from 'grapesjs';
 import plugin from 'grapesjs-preset-newsletter';
 import { NbDialogService } from '@commudle/theme';
+import { EDbModels } from '@commudle/shared-models';
 
 @Component({
   selector: 'commudle-newsletter-form',
@@ -24,7 +25,7 @@ export class NewsletterFormComponent implements OnInit, AfterViewInit {
   subscriptions: Subscription[] = [];
   imagePreview;
   testEmailsForms: FormGroup;
-
+  EDbModels = EDbModels;
   icons = {
     faChevronLeft,
     faFileImage,

--- a/apps/commudle-admin/src/app/app-shared-components/newsletter/newsletter-form/newsletter-form.component.ts
+++ b/apps/commudle-admin/src/app/app-shared-components/newsletter/newsletter-form/newsletter-form.component.ts
@@ -388,7 +388,16 @@ export class NewsletterFormComponent implements OnInit, AfterViewInit {
       }, 500);
     }
   }
+  redirectTo() {
+    let Url = '';
 
+    if (this.parentType === EDbModels.KOMMUNITY) {
+      Url = '/communities/' + this.parentId + '/newsletters/' + this.pageSlug;
+    } else if (this.parentType === EDbModels.COMMUNITY_GROUP) {
+      Url = '/orgs/' + this.parentId + '/newsletters/' + this.pageSlug;
+    }
+    window.open(Url, '_blank');
+  }
   getDefaultTemplate(): string {
     this.defaultTemplate = `<body style="box-sizing: border-box; margin: 0; margin-top: 0px; margin-right: 0px; margin-bottom: 0px; margin-left: 0px;">
   <table id="i0066" style="box-sizing: border-box; height: 40px; margin-top: 0px; margin-right: auto; margin-bottom: 10px; margin-left: auto; padding-top: 5px; padding-right: 5px; padding-bottom: 5px; padding-left: 5px; width: 100%;" width="100%" height="40">

--- a/apps/commudle-admin/src/app/app-shared-components/newsletter/newsletter-form/newsletter-form.component.ts
+++ b/apps/commudle-admin/src/app/app-shared-components/newsletter/newsletter-form/newsletter-form.component.ts
@@ -10,7 +10,6 @@ import { faChevronLeft, faFileImage } from '@fortawesome/free-solid-svg-icons';
 import grapesjs from 'grapesjs';
 import plugin from 'grapesjs-preset-newsletter';
 import { NbDialogService } from '@commudle/theme';
-import { Router } from '@angular/router';
 
 @Component({
   selector: 'commudle-newsletter-form',
@@ -80,7 +79,6 @@ export class NewsletterFormComponent implements OnInit, AfterViewInit {
     private location: Location,
     private toastrService: ToastrService,
     private dialogService: NbDialogService,
-    private router: Router,
   ) {
     this.newsletterForm = this.fb.group({
       title: ['', Validators.required],
@@ -155,18 +153,6 @@ export class NewsletterFormComponent implements OnInit, AfterViewInit {
         }
       }),
     );
-  }
-
-  redirectTo() {
-    let pathSegments: string[] = [];
-
-    if (this.parentType === 'Kommunity') {
-      pathSegments = ['communities', String(this.parentId), 'newsletters', this.pageSlug];
-    } else if (this.parentType === 'CommunityGroup') {
-      pathSegments = ['orgs', String(this.parentId), 'newsletters', this.pageSlug];
-    }
-
-    this.router.navigate(pathSegments);
   }
 
   initEditor() {


### PR DESCRIPTION
# PR Template

## Type

- ( ) Fix
- (X) Refactor
- ( ) Style
- ( ) Docs
- () Feat
- ( ) Hotfix
- ( ) Merge

## Description
This button allows users to preview a specific newsletter by opening its detailed view in a same tab.

## Screenshots
<img width="1127" height="388" alt="464109126-8a986f33-fd21-411a-b07f-1bffe9c949fb" src="https://github.com/user-attachments/assets/649d0698-4be3-4c0d-9ff7-e9067154ef23" />

## Testing

## Bundle Size