### PR TITLE
fix(newsletter): set max width of image in mobile view to 90dvw

### DIFF
--- a/apps/commudle-admin/src/app/app-shared-components/help-section/help-section.component.html
+++ b/apps/commudle-admin/src/app/app-shared-components/help-section/help-section.component.html
@@ -1,7 +1,12 @@
-<span (click)="openSidebar()">
-  <fa-icon *ngIf="helpDictionaryData.type === EHelpDictionaryType.URL" [icon]="faCircleQuestion"></fa-icon>
+<span
+  *ngIf="helpDictionaryData?.type === EHelpDictionaryType.URL"
+  (click)="openSidebar()"
+  [nbTooltip]="helpDictionaryData?.title || 'Help Info'"
+>
+  <fa-icon [icon]="faCircleQuestion" class="text-info"></fa-icon>
   <span *ngIf="helpDictionaryData?.title">{{ helpDictionaryData.title }}</span>
 </span>
+
 <fa-icon
   *ngIf="helpDictionaryData?.type === EHelpDictionaryType.TEXT"
   [icon]="faCircleQuestion"

--- a/apps/commudle-admin/src/app/app-shared-components/help-section/help-section.component.html
+++ b/apps/commudle-admin/src/app/app-shared-components/help-section/help-section.component.html
@@ -1,12 +1,7 @@
-<span
-  *ngIf="helpDictionaryData?.type === EHelpDictionaryType.URL"
-  (click)="openSidebar()"
-  [nbTooltip]="helpDictionaryData?.title || 'Help Info'"
->
-  <fa-icon [icon]="faCircleQuestion" class="text-info"></fa-icon>
+<span (click)="openSidebar()">
+  <fa-icon *ngIf="helpDictionaryData.type === EHelpDictionaryType.URL" [icon]="faCircleQuestion"></fa-icon>
   <span *ngIf="helpDictionaryData?.title">{{ helpDictionaryData.title }}</span>
 </span>
-
 <fa-icon
   *ngIf="helpDictionaryData?.type === EHelpDictionaryType.TEXT"
   [icon]="faCircleQuestion"

--- a/apps/commudle-admin/src/app/app-shared-components/newsletter/newsletter-form/newsletter-form.component.html
+++ b/apps/commudle-admin/src/app/app-shared-components/newsletter/newsletter-form/newsletter-form.component.html
@@ -91,7 +91,7 @@
         <div (click)="removeBannerImage()" class="delete-image">
           <button nbButton status="danger" outline size="small">Delete</button>
         </div>
-        <div class="com-max-w-full sm:com-max-w-[90dvw] com-mx-auto">
+        <div class="banner-image-wrapper">
           <commudle-banner-image
             [headerImagePath]="imagePreview || newsletterForm.controls['banner_image'].value"
           ></commudle-banner-image>

--- a/apps/commudle-admin/src/app/app-shared-components/newsletter/newsletter-form/newsletter-form.component.html
+++ b/apps/commudle-admin/src/app/app-shared-components/newsletter/newsletter-form/newsletter-form.component.html
@@ -93,6 +93,7 @@
         </div>
         <commudle-banner-image
           [headerImagePath]="imagePreview || newsletterForm.controls['banner_image'].value"
+          class="max-w-full sm:max-w-full max-w-[90px] mx-auto"
         ></commudle-banner-image>
       </div>
     </div>

--- a/apps/commudle-admin/src/app/app-shared-components/newsletter/newsletter-form/newsletter-form.component.html
+++ b/apps/commudle-admin/src/app/app-shared-components/newsletter/newsletter-form/newsletter-form.component.html
@@ -91,10 +91,11 @@
         <div (click)="removeBannerImage()" class="delete-image">
           <button nbButton status="danger" outline size="small">Delete</button>
         </div>
-        <commudle-banner-image
-          [headerImagePath]="imagePreview || newsletterForm.controls['banner_image'].value"
-          class="max-w-full sm:max-w-full max-w-[90px] mx-auto"
-        ></commudle-banner-image>
+        <div class="max-w-full sm:max-w-[90px] mx-auto">
+          <commudle-banner-image
+            [headerImagePath]="imagePreview || newsletterForm.controls['banner_image'].value"
+          ></commudle-banner-image>
+        </div>
       </div>
     </div>
 

--- a/apps/commudle-admin/src/app/app-shared-components/newsletter/newsletter-form/newsletter-form.component.html
+++ b/apps/commudle-admin/src/app/app-shared-components/newsletter/newsletter-form/newsletter-form.component.html
@@ -91,7 +91,7 @@
         <div (click)="removeBannerImage()" class="delete-image">
           <button nbButton status="danger" outline size="small">Delete</button>
         </div>
-        <div class="max-w-full sm:max-w-[90px] mx-auto">
+        <div class="com-max-w-full sm:com-max-w-[90dvw] com-mx-auto">
           <commudle-banner-image
             [headerImagePath]="imagePreview || newsletterForm.controls['banner_image'].value"
           ></commudle-banner-image>

--- a/apps/commudle-admin/src/app/app-shared-components/newsletter/newsletter-form/newsletter-form.component.scss
+++ b/apps/commudle-admin/src/app/app-shared-components/newsletter/newsletter-form/newsletter-form.component.scss
@@ -38,3 +38,7 @@ nb-card {
     @apply com-flex com-justify-between com-items-center;
   }
 }
+
+.banner-image-wrapper {
+  @apply com-max-w-full md:com-max-w-[90dvw] com-mx-auto;
+}


### PR DESCRIPTION
# PR Template

## Type

- (X) Fix
- ( ) Refactor
- ( ) Style
- ( ) Docs
- ( ) Feat
- ( ) Hotfix
- ( ) Merge

## Description
set max width of image in mobile view to 90px

## Screenshots
<img width="718" height="611" alt="image" src="https://github.com/user-attachments/assets/fea42e7e-5f73-4d1d-931a-9cef47994522" />


## Testing

## Bundle Size