### PR TITLE
fix(user-social-card): prevent event propagation on delete button click

### DIFF
--- a/apps/commudle-admin/src/app/feature-modules/users/components/public-profile/user-extra-details/user-social/user-social-card/user-social-card.component.html
+++ b/apps/commudle-admin/src/app/feature-modules/users/components/public-profile/user-extra-details/user-social/user-social-card/user-social-card.component.html
@@ -34,7 +34,7 @@
           <p class="user-social-card-description">{{ socialResource.description | truncatetext : 150 }}</p>
         </div>
         <button
-          (click)="onDialogOpen()"
+          (click)="onDialogOpen($event)"
           *ngIf="currentUser?.id === user.id"
           class="user-social-card-delete"
           ghost

--- a/apps/commudle-admin/src/app/feature-modules/users/components/public-profile/user-extra-details/user-social/user-social-card/user-social-card.component.ts
+++ b/apps/commudle-admin/src/app/feature-modules/users/components/public-profile/user-extra-details/user-social/user-social-card/user-social-card.component.ts
@@ -22,7 +22,9 @@ export class UserSocialCardComponent implements OnInit {
 
   ngOnInit(): void {}
 
-  onDialogOpen() {
+  onDialogOpen(event: Event) {
+    event.stopPropagation();
+    event.preventDefault();
     this.nbDialogService.open(this.confirmationDialog);
   }
 


### PR DESCRIPTION
- Add event parameter to onDialogOpen method
- Call stopPropagation and preventDefault to prevent unwanted event bubbling
- Fixes issue where clicking delete button could trigger parent link navigation

# PR Template

## Type

- (X) Fix
- ( ) Refactor
- ( ) Style
- ( ) Docs
- ( ) Feat
- ( ) Hotfix
- ( ) Merge
- ( ) Revamp
- ( ) Chore

## Description

This PR fixes an event handling issue in the user social card component where clicking the delete button could trigger unwanted navigation to the social resource link due to event bubbling.

**Changes made:**
- Added `$event` parameter to the `onDialogOpen()` method call in the template
- Updated the `onDialogOpen()` method to accept an `Event` parameter
- Added `event.stopPropagation()` to prevent event bubbling
- Added `event.preventDefault()` to prevent default behavior

**Problem solved:**
Previously, when users clicked the delete button on a social card, the click event would bubble up to the parent anchor tag, causing unwanted navigation to the social resource link instead of opening the delete confirmation dialog.

## Screenshots

No visual changes - this is a behavioural fix that prevents unwanted navigation.

## Testing

- [x] Verified that clicking the delete button now properly opens the confirmation dialog
- [x] Confirmed that clicking the delete button no longer triggers navigation to the social resource link
- [x] Tested that other clickable areas of the social card still work as expected
- [x] No linting errors introduced

## Bundle Size

No impact on bundle size - only added event handling logic.