### PR TITLE
fix(events): clear tax fields when has_taxes is disabled in payment settings

### DIFF
--- a/apps/commudle-admin/src/app/feature-modules/events/components/event-registrations/form-groups/payment-settings/payment-settings.component.ts
+++ b/apps/commudle-admin/src/app/feature-modules/events/components/event-registrations/form-groups/payment-settings/payment-settings.component.ts
@@ -233,12 +233,14 @@ export class PaymentSettingsComponent implements OnInit {
   toggleHasTaxes(event) {
     if (!event) {
       this.paidTicketingForm.patchValue({
-        tax_name: '',
-        tax_percentage: '',
-        seller_tax_details: '',
-        country: '',
-        seller_name: '',
-        seller_address: '',
+        paid_ticket_setting: {
+          tax_name: '',
+          tax_percentage: '',
+          seller_tax_details: '',
+          country: '',
+          seller_name: '',
+          seller_address: '',
+        },
       });
     }
   }


### PR DESCRIPTION
# PR Template

## Type

- (X) Fix
- ( ) Refactor
- ( ) Style
- ( ) Docs
- ( ) Feat
- ( ) Hotfix
- ( ) Merge
- ( ) Revamp
- ( ) Chore

## Description

## Screenshots

## Testing

## Bundle Size
