### PR TITLE
refactor(ui): display mutual followers on community member profiles

### DIFF
--- a/apps/commudle-admin/src/app/feature-modules/public-community/components/members/members.component.html
+++ b/apps/commudle-admin/src/app/feature-modules/public-community/components/members/members.component.html
@@ -140,6 +140,7 @@
                 [showLeaderBadgeToNameHeader]="true"
                 [appearanceOfFollowButton]="'outline'"
                 [showCompanyName]="true"
+                [showMutuals]="true"
               ></app-user-profile-card-large>
             </div>
           </ng-container>

--- a/apps/shared-modules/mini-user-profile/components/profile-cards/user-profile-card-large/user-profile-card-large.component.html
+++ b/apps/shared-modules/mini-user-profile/components/profile-cards/user-profile-card-large/user-profile-card-large.component.html
@@ -69,16 +69,16 @@
           <fa-icon class="user-company-icon" [icon]="faBriefcase"></fa-icon>
           <p class="user-company-name">{{ user.company_name }}</p>
         </div>
-        <span *ngIf="user.mutual_followee" class="mutuals"
-          >You both follow
-          <span *ngFor="let mutual of user.mutual_followee.first_three; let last = last"
-            ><a [routerLink]="['/users', mutual.username]">{{ mutual.name }}</a
-            ><span *ngIf="!last">, </span></span
-          >
-          <span *ngIf="user.mutual_followee.remaining_count > 0"
-            >and {{ user.mutual_followee.remaining_count }} others</span
-          >
+        @if (showMutuals && user.user_mutuals) {
+        <span class="mutuals">
+          You both follow @for (mutual of user.user_mutuals.mutual_followees_preview; track mutual.username; let last =
+          $last) {
+          <a [routerLink]="['/users', mutual.username]">{{ mutual.name }}</a
+          >@if (!last) {, } } @if (user.user_mutuals.mutual_followees -
+          user.user_mutuals.mutual_followees_preview.length > 0) { and
+          {{ user.user_mutuals.mutual_followees - user.user_mutuals.mutual_followees_preview.length }} others }
         </span>
+        }
         <div
           *ngIf="(showSpeakersCount && !alignSpeakerCountToRight) || showLeaderBadgeToSpeakerCount"
           class="talks-leader"

--- a/apps/shared-modules/mini-user-profile/components/profile-cards/user-profile-card-large/user-profile-card-large.component.ts
+++ b/apps/shared-modules/mini-user-profile/components/profile-cards/user-profile-card-large/user-profile-card-large.component.ts
@@ -28,6 +28,7 @@ export class UserProfileCardLargeComponent implements OnInit {
   @Input() showLeaderBadgeToNameHeader = false;
   @Input() showCompanyName = false;
   @Input() showLeaderBadgeToSpeakerCount = false;
+  @Input() showMutuals = false;
   @Output() componentClicked = new EventEmitter();
 
   faBriefcase = faBriefcase;

--- a/libs/shared/models/src/lib/user.model.ts
+++ b/libs/shared/models/src/lib/user.model.ts
@@ -63,9 +63,9 @@ export interface IUser {
   user_domain: string;
   goals: string[];
   blocked: boolean;
-  mutual_followee: {
-    first_three: IUser[];
-    remaining_count: number;
+  user_mutuals: {
+    mutual_followees_preview: IUser[];
+    mutual_followees: number;
   };
 }
 


### PR DESCRIPTION
# PR Template

## Type

- (X) Fix
- (X) Refactor
- ( ) Style
- ( ) Docs
- ( ) Feat
- ( ) Hotfix
- ( ) Merge
- ( ) Revamp
- ( ) Chore

## Description
- added @Input() showMutuals to user-profile-card-large component
- updated user model to use user_mutuals with preview and count
- conditionally render mutual followers section in template
- adjusted members component to enable mutuals display

## Screenshots

## Testing

## Bundle Size
