### PR TITLE
fix(hackathon): update status filter email functionality

### DIFF
--- a/apps/commudle-admin/src/app/feature-modules/hackathon-control-panel/components/hackathon-control-panel-emails/hackathon-status-filter-general-emails/hackathon-status-filter-general-emails.component.html
+++ b/apps/commudle-admin/src/app/feature-modules/hackathon-control-panel/components/hackathon-control-panel-emails/hackathon-status-filter-general-emails/hackathon-status-filter-general-emails.component.html
@@ -31,27 +31,30 @@
           value="Selected Registration Option"
           class="radio-btn"
         />
-        <label for="SelectedRegistrationOption">Selected Registration Option</label>
+        <label for="SelectedRegistrationOption">Selected Team registration status</label>
       </div>
       <select
         name=""
         id=""
         *ngIf="selectedRecipient === 'Selected Registration Option'"
-        [(ngModel)]="selectedStatus"
+        [(ngModel)]="selectedHackathonTeamStatus"
         class="selected-status"
       >
         <option disabled selected value="">Select Status</option>
-        <option *ngFor="let InvitationStatus of EInvitationStatus | keyvalue" [value]="InvitationStatus.value">
-          {{ InvitationStatus.value | capitalizeAndRemoveUnderscore }}
+        <option
+          *ngFor="let registrationStatus of EHackathonRegistrationStatus | keyvalue"
+          [value]="registrationStatus.value"
+        >
+          {{ registrationStatus.value | capitalizeAndRemoveUnderscore }}
         </option>
       </select>
     </div>
     <div class="subject">
-      <label for="emailReason">Subject<span class="mandatory-field">*</span></label>
+      <label for="emailReason">Subject<span class="mandatory-field"> *</span></label>
       <input type="text" placeholder="Subject" [(ngModel)]="subject" nbInput fullWidth />
     </div>
     <div class="message-field">
-      <label for="message" class="message">Message (Optional)</label>
+      <label for="message" class="message">Message<span class="mandatory-field"> *</span></label>
       <editor [init]="tinyMCE" [(ngModel)]="message"></editor>
     </div>
   </nb-card-body>
@@ -63,7 +66,7 @@
       shape="semi-round"
       [nbSpinner]="showPreviewSpinner"
       type="button"
-      [disabled]="showPreviewSpinner || subject.length === 0"
+      [disabled]="showPreviewSpinner || subject.length === 0 || message.length === 0"
     >
       Preview Email
     </button>
@@ -74,7 +77,7 @@
       fullWidth
       (click)="SendStatusFilterGeneralMailer()"
       [nbSpinner]="isLoading"
-      [disabled]="isLoading || subject.length === 0"
+      [disabled]="showPreviewSpinner || subject.length === 0 || message.length === 0"
     >
       Send
     </button>

--- a/apps/commudle-admin/src/app/feature-modules/hackathon-control-panel/components/hackathon-control-panel-emails/hackathon-status-filter-general-emails/hackathon-status-filter-general-emails.component.ts
+++ b/apps/commudle-admin/src/app/feature-modules/hackathon-control-panel/components/hackathon-control-panel-emails/hackathon-status-filter-general-emails/hackathon-status-filter-general-emails.component.ts
@@ -2,7 +2,7 @@ import { Component, Input } from '@angular/core';
 import { EmailerPreviewService, ToastrService } from '@commudle/shared-services';
 import { NbDialogRef, NbDialogService } from '@commudle/theme';
 import { HackathonService } from 'apps/commudle-admin/src/app/services/hackathon.service';
-import { EInvitationStatus } from '@commudle/shared-models';
+import { EHackathonRegistrationStatus, EInvitationStatus } from '@commudle/shared-models';
 import { FormBuilder, Validators } from '@angular/forms';
 import { EmailPreviewComponent } from 'apps/commudle-admin/src/app/app-shared-components/email-preview/email-preview.component';
 
@@ -18,7 +18,8 @@ export class HackathonStatusFilterGeneralEmailsComponent {
   isLoading = false;
   selectedRecipient = 'all';
   EInvitationStatus = EInvitationStatus;
-  selectedStatus = '';
+  EHackathonRegistrationStatus = EHackathonRegistrationStatus;
+  selectedHackathonTeamStatus: EHackathonRegistrationStatus | '' = '';
   showPreviewSpinner = false;
   previewEmailForm;
   previewData: string;
@@ -69,7 +70,7 @@ export class HackathonStatusFilterGeneralEmailsComponent {
     protected dialogRef: NbDialogRef<HackathonStatusFilterGeneralEmailsComponent>,
   ) {
     this.previewEmailForm = this.fb.group({
-      body: [''],
+      body: ['', Validators.required],
       subject: ['', Validators.required],
     });
   }
@@ -77,13 +78,19 @@ export class HackathonStatusFilterGeneralEmailsComponent {
   SendStatusFilterGeneralMailer() {
     this.isLoading = true;
     this.hackathonService
-      .StatusFilterGeneralEmail(this.hackathonId, this.message, this.subject, this.selectedStatus)
+      .StatusFilterGeneralEmail(
+        this.hackathonId,
+        this.message,
+        this.subject,
+        (this.selectedHackathonTeamStatus as EHackathonRegistrationStatus) || undefined,
+        undefined,
+      )
       .subscribe(
         (data) => {
           if (data) {
             this.toastrService.successDialog('Email sent successfully, Will be delivered soon!');
+            this.closeDialogBox();
           }
-          this.closeDialogBox();
         },
         () => {
           this.closeDialogBox();
@@ -93,7 +100,7 @@ export class HackathonStatusFilterGeneralEmailsComponent {
 
   onRecipientChange() {
     if (this.selectedRecipient === 'all') {
-      this.selectedStatus = '';
+      this.selectedHackathonTeamStatus = '';
     }
   }
 

--- a/apps/commudle-admin/src/app/feature-modules/public-hackathon/components/public-hackathon-registration/public-hackathon-registration.component.html
+++ b/apps/commudle-admin/src/app/feature-modules/public-hackathon/components/public-hackathon-registration/public-hackathon-registration.component.html
@@ -2,15 +2,17 @@
   <nb-card-header *ngIf="canEditForm">
     <div class="heading"></div>
     <div>
-      Registration Status: Profile Submitted for Review
+      Registration Status: {{ userTeamDetails.registration_status | titlecase }}&nbsp;
       <a [routerLink]="['/communities', hackathon.community.slug, 'hackathons', hackathon.slug, 'fill-form', hrgId]"
-        >Edit Your Response</a
+        >Edit your registration form response</a
       >
     </div>
   </nb-card-header>
 
   <nb-card-body>
-    <div class="round-details">Next: Round 1 confirmation</div>
+    @if(userTeamDetails?.round?.name){
+    <div class="round-details">Current Round: {{ userTeamDetails.round.name | titlecase }}</div>
+    }
     <div *ngIf="userTeamDetails.registration_status === EHackathonRegistrationStatus.ACCEPTED && canSubmitProject">
       <a
         *ngIf="!userTeamDetails.community_build"

--- a/apps/commudle-admin/src/app/services/hackathon.service.ts
+++ b/apps/commudle-admin/src/app/services/hackathon.service.ts
@@ -10,6 +10,8 @@ import { Injectable } from '@angular/core';
 import { API_ROUTES } from '@commudle/shared-services';
 import { Observable } from 'rxjs';
 import {
+  EHackathonRegistrationStatus,
+  EInvitationStatus,
   ICommunityBuild,
   ICommunityChannel,
   IHackathonPrize,
@@ -437,12 +439,19 @@ export class HackathonService {
     });
   }
 
-  StatusFilterGeneralEmail(hackathonId, message: string, subject: string, selectedStatus: string): Observable<boolean> {
+  StatusFilterGeneralEmail(
+    hackathonId,
+    message: string,
+    subject: string,
+    teamStatus?: EHackathonRegistrationStatus,
+    hurStatus?: EInvitationStatus,
+  ): Observable<boolean> {
     return this.http.post<boolean>(this.apiRoutesService.getRoute(API_ROUTES.HACKATHONS.STATUS_FILTER_GENERAL_EMAIL), {
       hackathon_id: hackathonId,
       message: message,
       subject: subject,
-      selected_status: selectedStatus,
+      team_status: teamStatus,
+      hur_status: hurStatus,
     });
   }
 


### PR DESCRIPTION
# PR Template

## Type

- (X) Fix
- ( ) Refactor
- ( ) Style
- ( ) Docs
- ( ) Feat
- ( ) Hotfix
- ( ) Merge
- ( ) Revamp
- ( ) Chore

## Description
- update email validation to require the message field
- ensure dialog closes after successful email send
- Update filter for hackathon team status instead of hur status
- Updated link text for editing registration form response
- Conditionally display current round details only when available

## Screenshots

## Testing

## Bundle Size
