### PR TITLE
feat(hackathon): add form closed dialog and application date validation

### DIFF
--- a/apps/commudle-admin/src/app/feature-modules/public-hackathon/components/public-hackathon-form/public-hackathon-form.component.html
+++ b/apps/commudle-admin/src/app/feature-modules/public-hackathon/components/public-hackathon-form/public-hackathon-form.component.html
@@ -160,3 +160,21 @@
     </nb-card-footer>
   </nb-card>
 </ng-template>
+
+<ng-template #formClosedDialog>
+  <nb-card class="form-closed-dialog">
+    <nb-card-body>
+      <div class="dialog-content">
+        <p class="icon">
+          <nb-icon icon="close-circle" status="danger"></nb-icon>
+        </p>
+        <h3>Application Closed</h3>
+        <p>The application period for this hackathon has ended. You can no longer submit applications.</p>
+        <p><strong>Application closed on:</strong> {{ hackathon.application_end_date | date : 'medium' }}</p>
+      </div>
+    </nb-card-body>
+    <nb-card-footer>
+      <button nbButton status="primary" (click)="closeFormDialog()">Go to Hackathon Page</button>
+    </nb-card-footer>
+  </nb-card>
+</ng-template>

--- a/apps/commudle-admin/src/app/feature-modules/public-hackathon/components/public-hackathon-form/public-hackathon-form.component.scss
+++ b/apps/commudle-admin/src/app/feature-modules/public-hackathon/components/public-hackathon-form/public-hackathon-form.component.scss
@@ -58,3 +58,31 @@ nb-stepper {
     @apply com-bg-[#F6F9FC] hover:com-bg-[#eef2f7]/50 com-cursor-pointer com-border-0 com-w-full;
   }
 }
+
+.form-closed-dialog {
+  @apply com-m-0 com-w-auto com-max-w-md;
+
+  .dialog-content {
+    @apply com-text-center com-py-4;
+
+    .icon {
+      @apply com-m-0 com-mb-4;
+
+      nb-icon {
+        @apply com-text-6xl;
+      }
+    }
+
+    h3 {
+      @apply com-text-xl com-font-bold com-mb-4 com-text-red-500;
+    }
+
+    p {
+      @apply com-mb-2 com-text-gray-600;
+    }
+  }
+
+  nb-card-footer {
+    @apply com-text-center;
+  }
+}

--- a/apps/commudle-admin/src/app/feature-modules/public-hackathon/components/public-hackathon-form/public-hackathon-form.component.ts
+++ b/apps/commudle-admin/src/app/feature-modules/public-hackathon/components/public-hackathon-form/public-hackathon-form.component.ts
@@ -40,8 +40,10 @@ export class PublicHackathonFormComponent implements OnInit, OnDestroy {
 
   @ViewChild('stepper') stepper: NbStepperComponent;
   @ViewChild('formConfirmationDialog', { static: true }) formConfirmationDialog: TemplateRef<any>;
+  @ViewChild('formClosedDialog', { static: true }) formClosedDialog: TemplateRef<any>;
   isLoading = true;
   hasTeammateOption = false;
+  isFormClosed = false;
 
   icons = {
     faLinkedinIn,
@@ -87,6 +89,7 @@ export class PublicHackathonFormComponent implements OnInit, OnDestroy {
       this.activatedRoute.parent.data.subscribe((data) => {
         this.hackathon = data.hackathon;
         this.community = data.community;
+        this.checkApplicationDates();
         this.getContactInfo();
         if (this.hackathon.participate_types === EParticipateTypes.TEAM) {
           this.hasTeammateOption = true;
@@ -108,6 +111,28 @@ export class PublicHackathonFormComponent implements OnInit, OnDestroy {
     this.destroy$.next();
     this.destroy$.complete();
     this.dialogRef?.close();
+  }
+
+  checkApplicationDates() {
+    const currentDate = new Date();
+    const applicationEndDate = new Date(this.hackathon.application_end_date);
+
+    if (currentDate > applicationEndDate) {
+      this.isFormClosed = true;
+      this.showFormClosedDialog();
+    }
+  }
+
+  showFormClosedDialog() {
+    this.dialogRef = this.dialogService.open(this.formClosedDialog, {
+      closeOnBackdropClick: false,
+      closeOnEsc: false,
+    });
+  }
+
+  closeFormDialog() {
+    this.dialogRef?.close();
+    this.router.navigate(['/communities', this.community.slug, 'hackathons', this.hackathon.slug]);
   }
 
   getContactInfo() {


### PR DESCRIPTION
# PR Template

## Type

- (X) Fix
- (X) Refactor
- ( ) Style
- ( ) Docs
- ( ) Feat
- ( ) Hotfix
- ( ) Merge
- ( ) Revamp
- ( ) Chore

## Description
- Implemented a dialog to notify users when hackathon applications are closed
- Added date validation to prevent submissions after the application end date
- Included styling and template for the form closed dialog
- Updated component logic to check application dates on initialization


## Screenshots

## Testing

## Bundle Size
