### PR TITLE
feat(hackathon): add team member editing functionality

### DIFF
--- a/apps/commudle-admin/src/app/feature-modules/public-hackathon/components/public-hackathon-form/public-hackathon-teammate-form/public-hackathon-teammate-form.component.html
+++ b/apps/commudle-admin/src/app/feature-modules/public-hackathon/components/public-hackathon-form/public-hackathon-teammate-form/public-hackathon-teammate-form.component.html
@@ -53,7 +53,7 @@
       </section>
 
       <button
-        *ngIf="hackathonUserResponse.current_user_is_team_lead"
+        *ngIf="hackathonUserResponse.current_user_is_team_lead || team.user_id === hackathonUserResponse.user_id"
         type="button"
         nbButton
         ghost
@@ -81,6 +81,21 @@
   </button>
 
   <div class="action-buttons">
+    @if(hasSubmitButton){
+    <button
+      type="submit"
+      (click)="submitTeammateDetails()"
+      nbButton
+      status="primary"
+      fullWidth
+      [disabled]="
+        teammateForm.invalid ||
+        (hasTeammateOption && hackathon.min_number_of_teammates - 1 > teammatesArray.controls.length)
+      "
+    >
+      Save
+    </button>
+    }@else{
     <button status="primary" nbButton (click)="previousButton()">Previous</button>
     <button
       type="submit"
@@ -94,5 +109,6 @@
     >
       Next
     </button>
+    }
   </div>
 </form>

--- a/apps/commudle-admin/src/app/feature-modules/public-hackathon/components/public-hackathon-form/public-hackathon-teammate-form/public-hackathon-teammate-form.component.ts
+++ b/apps/commudle-admin/src/app/feature-modules/public-hackathon/components/public-hackathon-form/public-hackathon-teammate-form/public-hackathon-teammate-form.component.ts
@@ -19,7 +19,7 @@ import { LibAuthwatchService } from 'apps/shared-services/lib-authwatch.service'
 import { ICurrentUser } from 'apps/shared-models/current_user.model';
 import { IHackathon } from 'apps/shared-models/hackathon.model';
 import { ToastrService } from '@commudle/shared-services';
-import { IHackathonUserResponse } from '@commudle/shared-models';
+import { IHackathonTeam, IHackathonUserResponse } from '@commudle/shared-models';
 import { Subject, takeUntil } from 'rxjs';
 
 @Component({
@@ -31,7 +31,9 @@ export class PublicHackathonTeammateFormComponent implements OnInit, AfterViewIn
   @Input() hackathonUserResponse: IHackathonUserResponse;
   @Input() hackathonResponseGroup: IHackathonResponseGroup;
   @Input() hasTeammateOption: boolean;
+  @Input() hasSubmitButton = false;
   @Input() hackathon: IHackathon;
+  @Input() team: IHackathonTeam;
   @Output() submitTeammateDetailsEvent = new EventEmitter<any>();
   @Output() previousButtonEvent = new EventEmitter<any>();
   showEmailError = false;

--- a/apps/commudle-admin/src/app/feature-modules/public-hackathon/components/public-hackathon-user-dashboard/public-hackathon-user-dashboard.component.html
+++ b/apps/commudle-admin/src/app/feature-modules/public-hackathon/components/public-hackathon-user-dashboard/public-hackathon-user-dashboard.component.html
@@ -53,6 +53,9 @@
       <nb-card class="team-details-container">
         <nb-card-header>
           <h5>{{ userTeamDetails[selectedTeamIndex].name }}</h5>
+          <button nbButton ghost status="primary" (click)="openEditTeamMembersDialog()">
+            <fa-icon [icon]="icons.faEdit"></fa-icon> &nbsp; Edit Team Members
+          </button>
         </nb-card-header>
         <nb-card-body>
           <div
@@ -64,7 +67,7 @@
               <span>{{ hur.user_email }}</span>
               <span>{{ hur.invite_status | capitalizeAndRemoveUnderscore }}</span>
             </div>
-            <div>
+            <!-- <div>
               <button
                 nbButton
                 ghost
@@ -74,7 +77,7 @@
               >
                 <fa-icon [icon]="icons.faUserMinus"></fa-icon> &nbsp; Remove
               </button>
-            </div>
+            </div> -->
             <div
               *ngIf="
                 hur.invite_status === EInvitationStatus.INCOMPLETE_APPLICATION ||
@@ -149,5 +152,27 @@
       </button>
       <button nbButton ghost (click)="ref.close()">Cancel</button>
     </nb-card-footer>
+  </nb-card>
+</ng-template>
+
+<ng-template #editTeamMembersDialog let-data let-ref="dialogRef">
+  <nb-card class="edit-team-members-dialog">
+    <nb-card-header>
+      <span>Edit {{ data.selectedTeam.name }} Members</span>
+      <button ghost nbButton size="small" (click)="ref.close()" shape="round">
+        <fa-icon [icon]="icons.faXmark"></fa-icon>
+      </button>
+    </nb-card-header>
+    <nb-card-body>
+      <commudle-public-hackathon-teammate-form
+        [hackathonUserResponse]="data.hackathonUserResponse"
+        [hackathonResponseGroup]="data.hackathonResponseGroup"
+        [hasTeammateOption]="hasTeammateOption"
+        [hackathon]="hackathon"
+        [team]="data.selectedTeam"
+        [hasSubmitButton]="true"
+        (submitTeammateDetailsEvent)="submitTeammateDetails($event, ref, data.hackathonUserResponse.id)"
+      ></commudle-public-hackathon-teammate-form>
+    </nb-card-body>
   </nb-card>
 </ng-template>

--- a/apps/commudle-admin/src/app/feature-modules/public-hackathon/components/public-hackathon-user-dashboard/public-hackathon-user-dashboard.component.scss
+++ b/apps/commudle-admin/src/app/feature-modules/public-hackathon/components/public-hackathon-user-dashboard/public-hackathon-user-dashboard.component.scss
@@ -82,3 +82,10 @@ nb-card {
     }
   }
 }
+
+.edit-team-members-dialog {
+  @apply com-w-full md:com-w-[30dvw] com-max-h-90dvh;
+  nb-card-header {
+    @apply com-flex com-justify-between com-items-center;
+  }
+}

--- a/apps/commudle-admin/src/app/feature-modules/public-hackathon/components/public-hackathon-user-dashboard/public-hackathon-user-dashboard.component.ts
+++ b/apps/commudle-admin/src/app/feature-modules/public-hackathon/components/public-hackathon-user-dashboard/public-hackathon-user-dashboard.component.ts
@@ -1,21 +1,23 @@
 /* eslint-disable @nx/enforce-module-boundaries */
-import { Component, OnDestroy, OnInit, TemplateRef } from '@angular/core';
+import { Component, OnDestroy, OnInit, TemplateRef, ViewChild } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import {
   EDbModels,
   EDiscussionType,
   EInvitationStatus,
+  EParticipateTypes,
   ICommunityChannel,
   IHackathonTeam,
   IHackathonUserResponse,
 } from '@commudle/shared-models';
 import { AuthService, CommunityChannelsService, ToastrService } from '@commudle/shared-services';
 import { NbDialogService } from '@commudle/theme';
-import { faArrowRight, faUserMinus, faXmark } from '@fortawesome/free-solid-svg-icons';
+import { faArrowRight, faUserMinus, faXmark, faEdit } from '@fortawesome/free-solid-svg-icons';
 import { HackathonResponseGroupService } from 'apps/commudle-admin/src/app/services/hackathon-response-group.service';
 import { HackathonUserResponsesService } from 'apps/commudle-admin/src/app/services/hackathon-user-responses.service';
 import { HackathonService } from 'apps/commudle-admin/src/app/services/hackathon.service';
 import { IHackathon } from 'apps/shared-models/hackathon.model';
+import { IHackathonResponseGroup } from 'apps/shared-models/hackathon-response-group.model';
 import { Subject, Subscription, takeUntil } from 'rxjs';
 @Component({
   selector: 'commudle-public-hackathon-user-dashboard',
@@ -27,6 +29,7 @@ export class PublicHackathonUserDashboardComponent implements OnInit, OnDestroy 
     faArrowRight,
     faUserMinus,
     faXmark,
+    faEdit,
   };
   hackathon: IHackathon;
   subscriptions: Subscription[] = [];
@@ -37,7 +40,10 @@ export class PublicHackathonUserDashboardComponent implements OnInit, OnDestroy 
   EDiscussionType = EDiscussionType;
   channels: ICommunityChannel[];
   EInvitationStatus = EInvitationStatus;
+  hackathonResponseGroup: IHackathonResponseGroup;
+  hasTeammateOption = false;
 
+  @ViewChild('editTeamMembersDialog') editTeamMembersDialogRef: TemplateRef<any>;
   private destroy$ = new Subject<void>();
 
   constructor(
@@ -55,6 +61,9 @@ export class PublicHackathonUserDashboardComponent implements OnInit, OnDestroy 
     this.subscriptions.push(
       this.activatedRoute.parent.data.subscribe((data) => {
         this.hackathon = data.hackathon;
+        if (this.hackathon.participate_types === EParticipateTypes.TEAM) {
+          this.hasTeammateOption = true;
+        }
         this.getChannels();
         this.authService.currentUser$.pipe(takeUntil(this.destroy$)).subscribe((currentUser) => {
           if (currentUser) this.getHackathonCurrentRegistrationDetails();
@@ -62,6 +71,7 @@ export class PublicHackathonUserDashboardComponent implements OnInit, OnDestroy 
       }),
       this.hrgService.showHackathonResponseGroup(this.hackathon.id).subscribe((data) => {
         this.hrgId = data.id;
+        this.hackathonResponseGroup = data;
       }),
     );
   }
@@ -119,6 +129,27 @@ export class PublicHackathonUserDashboardComponent implements OnInit, OnDestroy 
     this.hackathonUserResponseService.resendInviteToTeammate(team.id, hur.id).subscribe((data) => {
       if (data) {
         this.toasterService.successDialog('Team member invite resent');
+      }
+    });
+  }
+
+  openEditTeamMembersDialog() {
+    const selectedTeam = this.userTeamDetails[this.selectedTeamIndex];
+    const hackathonUserResponse = selectedTeam.hackathon_user_responses[0];
+    this.nbDialogService.open(this.editTeamMembersDialogRef, {
+      context: {
+        hackathonUserResponse: hackathonUserResponse,
+        hackathonResponseGroup: this.hackathonResponseGroup,
+        selectedTeam: selectedTeam,
+      },
+    });
+  }
+
+  submitTeammateDetails(formData, dialogRef: any, hackathonUserResponseId) {
+    dialogRef.close();
+    this.hackathonUserResponseService.updateTeamDetails(formData, hackathonUserResponseId).subscribe((data) => {
+      if (data) {
+        this.toasterService.successDialog('Team members updated successfully');
       }
     });
   }


### PR DESCRIPTION
# PR Template

## Type

- ( ) Fix
- ( ) Refactor
- ( ) Style
- ( ) Docs
- (X) Feat
- ( ) Hotfix
- ( ) Merge
- ( ) Revamp
- ( ) Chore

## Description
- introduced edit team members dialog in the user dashboard
- updated teammate form to support submit button and team context
- added necessary inputs and event handlers for team updates
- implemented team member update logic with dialog integration

## Screenshots

## Testing

## Bundle Size
