### PR TITLE
feat(hackathon-email): add preview functionality for entry pass and rsvp emails

### DIFF
--- a/apps/commudle-admin/src/app/feature-modules/hackathon-control-panel/components/hackathon-control-panel-emails/hackathon-entry-pass-email/hackathon-entry-pass-email.component.html
+++ b/apps/commudle-admin/src/app/feature-modules/hackathon-control-panel/components/hackathon-control-panel-emails/hackathon-entry-pass-email/hackathon-entry-pass-email.component.html
@@ -44,6 +44,15 @@
     </div>
   </nb-card-body>
   <nb-card-footer>
+    <button
+      nbButton
+      status="primary"
+      (click)="previewEmail()"
+      [disabled]="entryPassForm.invalid || showPreviewSpinner"
+      [nbSpinner]="showPreviewSpinner"
+    >
+      Preview Email
+    </button>
     <button nbButton status="primary" (click)="sendEntryPassEmail()" [disabled]="entryPassForm.invalid" fullWidth>
       Send
     </button>

--- a/apps/commudle-admin/src/app/feature-modules/hackathon-control-panel/components/hackathon-control-panel-emails/hackathon-entry-pass-email/hackathon-entry-pass-email.component.ts
+++ b/apps/commudle-admin/src/app/feature-modules/hackathon-control-panel/components/hackathon-control-panel-emails/hackathon-entry-pass-email/hackathon-entry-pass-email.component.ts
@@ -1,7 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { NbDialogRef, NbDialogService } from '@commudle/theme';
-import { IHackathonTeam } from '@commudle/shared-models';
 import { HackathonService } from 'apps/commudle-admin/src/app/services/hackathon.service';
 import { EmailerPreviewService, ToastrService } from '@commudle/shared-services';
 import { IHackathon } from 'apps/shared-models/hackathon.model';

--- a/apps/commudle-admin/src/app/feature-modules/hackathon-control-panel/components/hackathon-control-panel-emails/hackathon-entry-pass-email/hackathon-entry-pass-email.component.ts
+++ b/apps/commudle-admin/src/app/feature-modules/hackathon-control-panel/components/hackathon-control-panel-emails/hackathon-entry-pass-email/hackathon-entry-pass-email.component.ts
@@ -1,11 +1,12 @@
 import { Component, OnInit } from '@angular/core';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
-import { NbDialogRef } from '@commudle/theme';
+import { NbDialogRef, NbDialogService } from '@commudle/theme';
 import { IHackathonTeam } from '@commudle/shared-models';
 import { HackathonService } from 'apps/commudle-admin/src/app/services/hackathon.service';
-import { ToastrService } from '@commudle/shared-services';
+import { EmailerPreviewService, ToastrService } from '@commudle/shared-services';
 import { IHackathon } from 'apps/shared-models/hackathon.model';
 import { IHackathonUserResponses } from 'apps/shared-models/hackathon-user-responses.model';
+import { EmailPreviewComponent } from 'apps/commudle-admin/src/app/app-shared-components/email-preview/email-preview.component';
 
 @Component({
   selector: 'commudle-hackathon-entry-pass-email',
@@ -17,6 +18,8 @@ export class HackathonEntryPassEmailComponent implements OnInit {
   hackathon: IHackathon;
   hackathonUserResponses: IHackathonUserResponses;
   isBulkEmail = false;
+  showPreviewSpinner = false;
+  dialogReference: NbDialogRef<any>;
 
   tinyMCE = {
     min_height: 300,
@@ -38,6 +41,8 @@ export class HackathonEntryPassEmailComponent implements OnInit {
     private dialogRef: NbDialogRef<HackathonEntryPassEmailComponent>,
     private hackathonService: HackathonService,
     private toastrService: ToastrService,
+    private emailerPreviewService: EmailerPreviewService,
+    private nbDialogService: NbDialogService,
   ) {}
 
   ngOnInit() {
@@ -70,6 +75,33 @@ export class HackathonEntryPassEmailComponent implements OnInit {
         this.toastrService.successDialog('Entry pass email sent successfully!');
         this.dialogRef.close();
       }
+    });
+  }
+
+  previewEmail() {
+    if (this.entryPassForm.invalid) {
+      this.toastrService.warningDialog('Please fill all required fields');
+      return;
+    }
+
+    this.showPreviewSpinner = true;
+    const previewData = {
+      message: this.entryPassForm.value.message,
+      subject: this.entryPassForm.value.subject,
+      hackathon_team_id: this.hackathonUserResponses.team.id,
+      hackathon_user_response_id: this.hackathonUserResponses.user_responses[0]?.id,
+    };
+    this.emailerPreviewService.hackathonEntryPassEmailPreview(previewData, this.hackathon.id).subscribe({
+      next: (result) => {
+        this.dialogReference = this.nbDialogService.open(EmailPreviewComponent, {
+          context: { previewData: result.preview },
+        });
+        this.showPreviewSpinner = false;
+      },
+      error: () => {
+        this.toastrService.errorDialog('Failed to generate email preview');
+        this.showPreviewSpinner = false;
+      },
     });
   }
 

--- a/apps/commudle-admin/src/app/feature-modules/hackathon-control-panel/components/hackathon-control-panel-emails/hackathon-rsvp-email/hackathon-rsvp-email.component.html
+++ b/apps/commudle-admin/src/app/feature-modules/hackathon-control-panel/components/hackathon-control-panel-emails/hackathon-rsvp-email/hackathon-rsvp-email.component.html
@@ -29,6 +29,15 @@
     </form>
   </nb-card-body>
   <nb-card-footer>
+    <button
+      nbButton
+      status="primary"
+      (click)="previewEmail()"
+      [disabled]="rsvpForm.invalid || showPreviewSpinner"
+      [nbSpinner]="showPreviewSpinner"
+    >
+      Preview Email
+    </button>
     <button nbButton status="primary" (click)="sendRsvpEmail()" [disabled]="rsvpForm.invalid" fullWidth>Send</button>
   </nb-card-footer>
 </nb-card>

--- a/apps/commudle-admin/src/app/feature-modules/hackathon-control-panel/components/hackathon-control-panel-emails/hackathon-rsvp-email/hackathon-rsvp-email.component.ts
+++ b/apps/commudle-admin/src/app/feature-modules/hackathon-control-panel/components/hackathon-control-panel-emails/hackathon-rsvp-email/hackathon-rsvp-email.component.ts
@@ -1,10 +1,11 @@
 import { Component, OnInit } from '@angular/core';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
-import { NbDialogRef } from '@commudle/theme';
+import { NbDialogRef, NbDialogService } from '@commudle/theme';
 import { IHackathonTeam } from '@commudle/shared-models';
 import { HackathonService } from 'apps/commudle-admin/src/app/services/hackathon.service';
-import { ToastrService } from '@commudle/shared-services';
+import { EmailerPreviewService, ToastrService } from '@commudle/shared-services';
 import { IHackathon } from 'apps/shared-models/hackathon.model';
+import { EmailPreviewComponent } from 'apps/commudle-admin/src/app/app-shared-components/email-preview/email-preview.component';
 
 @Component({
   selector: 'commudle-hackathon-rsvp-email',
@@ -17,6 +18,9 @@ export class HackathonRsvpEmailComponent implements OnInit {
   hackathon: IHackathon;
   isBulkEmail = false;
   resend = false;
+  previewData: string;
+  showPreviewSpinner = false;
+  dialogReference: NbDialogRef<any>;
 
   tinyMCE = {
     min_height: 300,
@@ -38,6 +42,8 @@ export class HackathonRsvpEmailComponent implements OnInit {
     private dialogRef: NbDialogRef<HackathonRsvpEmailComponent>,
     private hackathonService: HackathonService,
     private toastrService: ToastrService,
+    private emailerPreviewService: EmailerPreviewService,
+    private nbDialogService: NbDialogService,
   ) {}
 
   ngOnInit() {
@@ -70,6 +76,37 @@ export class HackathonRsvpEmailComponent implements OnInit {
         this.toastrService.successDialog('RSVP email sent successfully!');
         this.dialogRef.close();
       }
+    });
+  }
+
+  previewEmail() {
+    if (this.rsvpForm.invalid) {
+      this.toastrService.warningDialog('Please fill all required fields');
+      return;
+    }
+
+    this.showPreviewSpinner = true;
+    const previewData = {
+      message: this.rsvpForm.value.message,
+      subject: this.rsvpForm.value.subject,
+      hackathon_team_id: this.team.id,
+    };
+    this.emailerPreviewService.hackathonTeamRsvpEmailPreview(previewData, this.hackathon.id).subscribe({
+      next: (result) => {
+        this.previewData = result.preview;
+        this.openEmailPreviewTemplate(this.previewData);
+        this.showPreviewSpinner = false;
+      },
+      error: () => {
+        this.toastrService.errorDialog('Failed to generate email preview');
+        this.showPreviewSpinner = false;
+      },
+    });
+  }
+
+  openEmailPreviewTemplate(previewData) {
+    this.dialogReference = this.nbDialogService.open(EmailPreviewComponent, {
+      context: { previewData },
     });
   }
 

--- a/apps/commudle-admin/src/app/feature-modules/hackathon-control-panel/components/hackathon-control-panel-review/hackathon-control-panel-review.component.ts
+++ b/apps/commudle-admin/src/app/feature-modules/hackathon-control-panel/components/hackathon-control-panel-review/hackathon-control-panel-review.component.ts
@@ -653,6 +653,7 @@ export class HackathonControlPanelReviewComponent implements OnInit, OnDestroy {
   openBulkRsvpEmailDialog() {
     this.nbDialogService.open(HackathonRsvpEmailComponent, {
       context: {
+        team: this.userResponses[0].team,
         hackathon: this.hackathon,
         isBulkEmail: true,
       },
@@ -671,6 +672,7 @@ export class HackathonControlPanelReviewComponent implements OnInit, OnDestroy {
     this.nbDialogService.open(HackathonEntryPassEmailComponent, {
       context: {
         hackathon: this.hackathon,
+        hackathonUserResponses: this.userResponses[0],
         isBulkEmail: true,
       },
     });

--- a/libs/shared/services/src/lib/api-routes.constant.ts
+++ b/libs/shared/services/src/lib/api-routes.constant.ts
@@ -454,6 +454,8 @@ export const API_ROUTES = {
         'api/v2/email_previews/hackathon_emails/hackathon_team_individual_general_email',
       HACKATHON_SEND_TEAM_STATUS_EMAIL_BY_FILTER:
         'api/v2/email_previews/hackathon_emails/send_team_status_email_by_filter',
+      HACKATHON_TEAM_RSVP_EMAIL: 'api/v2/email_previews/hackathon_emails/hackathon_team_rsvp_email',
+      HACKATHON_ENTRY_PASS_EMAIL: 'api/v2/email_previews/hackathon_emails/hackathon_entry_pass_email',
     },
   },
 

--- a/libs/shared/services/src/lib/emailer-preview.service.ts
+++ b/libs/shared/services/src/lib/emailer-preview.service.ts
@@ -90,4 +90,24 @@ export class EmailerPreviewService {
       },
     );
   }
+
+  hackathonTeamRsvpEmailPreview(formData, hackathonId): Observable<any> {
+    return this.http.post<any>(
+      this.apiRoutesService.getRoute(API_ROUTES.EMAIL_PREVIEWS.HACKATHON_EMAILS.HACKATHON_TEAM_RSVP_EMAIL),
+      {
+        email_form: formData,
+        hackathon_id: hackathonId,
+      },
+    );
+  }
+
+  hackathonEntryPassEmailPreview(formData, hackathonId): Observable<any> {
+    return this.http.post<any>(
+      this.apiRoutesService.getRoute(API_ROUTES.EMAIL_PREVIEWS.HACKATHON_EMAILS.HACKATHON_ENTRY_PASS_EMAIL),
+      {
+        email_form: formData,
+        hackathon_id: String(hackathonId),
+      },
+    );
+  }
 }


### PR DESCRIPTION
# PR Template

## Type

- [ ] Fix
- [ ] Refactor
- [ ] Style
- [ ] Docs
- [x] Feat
- [ ] Hotfix
- [ ] Merge
- [ ] Revamp
- [ ] Chore

## Description

## Screenshots

## Testing

## Bundle Size
