### PR TITLE
fix(hackathon): disable track selection when no tracks available

### DIFF
--- a/apps/commudle-admin/src/app/feature-modules/hackathon-control-panel/components/hackathon-control-panel-registrations/hackathon-control-panel-registrations.component.html
+++ b/apps/commudle-admin/src/app/feature-modules/hackathon-control-panel/components/hackathon-control-panel-registrations/hackathon-control-panel-registrations.component.html
@@ -167,9 +167,22 @@
 
       <div>
         <div class="group-name">TRACK SELECTION</div>
-        <nb-checkbox status="basic" [(ngModel)]="allow_track_problem_statement_selection">
+        <nb-checkbox
+          status="basic"
+          [(ngModel)]="allow_track_problem_statement_selection"
+          [disabled]="hackathon?.tracks_count === 0"
+        >
           Allow track/problem statement selection
         </nb-checkbox>
+        <commudle-alert *ngIf="hackathon?.tracks_count === 0" [info]="true">
+          <div infoContent>
+            No tracks available. Please
+            <a [routerLink]="['/admin/communities', parent.slug, 'hackathon-dashboard', hackathon.slug, 'tracks']">
+              add tracks
+            </a>
+            to enable this option.
+          </div>
+        </commudle-alert>
       </div>
 
       <div>

--- a/apps/commudle-admin/src/app/feature-modules/hackathon-control-panel/components/hackathon-control-panel-registrations/hackathon-control-panel-registrations.component.ts
+++ b/apps/commudle-admin/src/app/feature-modules/hackathon-control-panel/components/hackathon-control-panel-registrations/hackathon-control-panel-registrations.component.ts
@@ -25,7 +25,7 @@ export class HackathonControlPanelRegistrationsComponent implements OnInit, OnDe
   dataFormId: number;
   hackathonResponseGroupDetails: IHackathonResponseGroup;
   filled_by_only_team_lead = true;
-  allow_track_problem_statement_selection = true;
+  allow_track_problem_statement_selection = false;
   icons = {
     faUpRightFromSquare,
     faArrowRight,

--- a/apps/commudle-admin/src/app/feature-modules/hackathon-control-panel/components/hackathon-control-panel-tracks-prizes/hackathon-control-panel-track/hackathon-control-panel-track.component.ts
+++ b/apps/commudle-admin/src/app/feature-modules/hackathon-control-panel/components/hackathon-control-panel-tracks-prizes/hackathon-control-panel-track/hackathon-control-panel-track.component.ts
@@ -92,6 +92,7 @@ export class HackathonControlPanelTrackComponent implements OnInit {
 
   removeProblemStatement(index: number): void {
     this.problemStatements.removeAt(index);
+    this.trackForm.markAsDirty();
   }
 
   openSponsorDialogBox(dialog, track?: IHackathonTrack, index?) {


### PR DESCRIPTION
# PR Template

## Type

- [X] Fix
- [ ] Refactor
- [ ] Style
- [ ] Docs
- [ ] Feat
- [ ] Hotfix
- [ ] Merge
- [ ] Revamp
- [ ] Chore

## Description
- Set default value of allow_track_problem_statement_selection to false
- Add conditional disabling of checkbox when tracks_count is zero
- Display alert message with link to add tracks when none exist
- Mark form as dirty when problem statements are removed

## Screenshots

## Testing

## Bundle Size
