### PR TITLE
feat(hackathon): add track and problem statement selection with confirmation dialogs

### DIFF
--- a/apps/commudle-admin/src/app/feature-modules/hackathon-control-panel/components/hackathon-control-panel-review/hackathon-control-panel-review.component.html
+++ b/apps/commudle-admin/src/app/feature-modules/hackathon-control-panel/components/hackathon-control-panel-review/hackathon-control-panel-review.component.html
@@ -669,7 +669,8 @@
         class="problem-statement-select"
         *ngIf="
           selectedTeamDetails.registration_status === EHackathonRegistrationStatus.ACCEPTED &&
-          hackathonProblemStatements.length > 0
+          selectedTeamDetails.track &&
+          getTrackProblemStatements(selectedTeamDetails.track.id).length > 0
         "
       >
         <label>Problem Statement:</label>
@@ -688,7 +689,7 @@
             [(ngModel)]="selectedTeamDetails.problem_statement.id"
           >
             <option
-              *ngFor="let hackathonProblemStatement of hackathonProblemStatements"
+              *ngFor="let hackathonProblemStatement of getTrackProblemStatements(selectedTeamDetails.track.id)"
               [value]="hackathonProblemStatement.id"
             >
               #{{ hackathonProblemStatement.display_id }}
@@ -710,7 +711,7 @@
           >
             <option selected disabled [value]="null">Select a problem statement</option>
             <option
-              *ngFor="let hackathonProblemStatement of hackathonProblemStatements"
+              *ngFor="let hackathonProblemStatement of getTrackProblemStatements(selectedTeamDetails.track.id)"
               [value]="hackathonProblemStatement.id"
             >
               #{{ hackathonProblemStatement.display_id }}
@@ -1147,6 +1148,11 @@
           Are you sure you want to change this team's track to <strong>{{ data.trackName }}</strong
           >?
         </p>
+        <commudle-alert
+          [error]="true"
+          errorMessage="Changing the track will remove their current problem statement. You'll need to select a
+          new problem statement from this track."
+        ></commudle-alert>
       </div>
     </nb-card-body>
     <nb-card-footer>

--- a/apps/commudle-admin/src/app/feature-modules/hackathon-control-panel/components/hackathon-control-panel-review/hackathon-control-panel-review.component.html
+++ b/apps/commudle-admin/src/app/feature-modules/hackathon-control-panel/components/hackathon-control-panel-review/hackathon-control-panel-review.component.html
@@ -636,6 +636,89 @@
         </div>
       </div>
 
+      <div
+        class="track-select"
+        *ngIf="
+          selectedTeamDetails.registration_status === EHackathonRegistrationStatus.ACCEPTED &&
+          hackathonTracks.length > 0
+        "
+      >
+        <label>Track:</label>
+        <div *ngIf="selectedTeamDetails.track">
+          <select
+            [id]="'track-select-' + selectedTeamDetails.id"
+            (mousedown)="storeOriginalTrackValue(selectedTeamDetails.track.id)"
+            (change)="
+              openTrackConfirmationDialogBox(
+                trackChangedConfirmationDialogBox,
+                $event,
+                selectedTeamDetails.id,
+                data.index
+              )
+            "
+            [(ngModel)]="selectedTeamDetails.track.id"
+          >
+            <option *ngFor="let hackathonTrack of hackathonTracks" [value]="hackathonTrack.id">
+              {{ hackathonTrack.name }}
+            </option>
+          </select>
+        </div>
+      </div>
+
+      <div
+        class="problem-statement-select"
+        *ngIf="
+          selectedTeamDetails.registration_status === EHackathonRegistrationStatus.ACCEPTED &&
+          hackathonProblemStatements.length > 0
+        "
+      >
+        <label>Problem Statement:</label>
+        <div *ngIf="selectedTeamDetails.problem_statement">
+          <select
+            [id]="'problem-statement-select-' + selectedTeamDetails.id"
+            (mousedown)="storeOriginalProblemStatementValue(selectedTeamDetails.problem_statement.id)"
+            (change)="
+              openProblemStatementConfirmationDialogBox(
+                problemStatementChangedConfirmationDialogBox,
+                $event,
+                selectedTeamDetails.id,
+                data.index
+              )
+            "
+            [(ngModel)]="selectedTeamDetails.problem_statement.id"
+          >
+            <option
+              *ngFor="let hackathonProblemStatement of hackathonProblemStatements"
+              [value]="hackathonProblemStatement.id"
+            >
+              #{{ hackathonProblemStatement.display_id }}
+            </option>
+          </select>
+        </div>
+        <div *ngIf="!selectedTeamDetails.problem_statement">
+          <select
+            [id]="'problem-statement-select-' + selectedTeamDetails.id"
+            (mousedown)="storeOriginalProblemStatementValue(selectedTeamDetails?.problem_statement?.id || null)"
+            (change)="
+              openProblemStatementConfirmationDialogBox(
+                problemStatementChangedConfirmationDialogBox,
+                $event,
+                selectedTeamDetails.id,
+                data.index
+              )
+            "
+          >
+            <option selected disabled [value]="null">Select a problem statement</option>
+            <option
+              *ngFor="let hackathonProblemStatement of hackathonProblemStatements"
+              [value]="hackathonProblemStatement.id"
+            >
+              #{{ hackathonProblemStatement.display_id }}
+            </option>
+          </select>
+        </div>
+      </div>
+
       <div [formGroup]="notesForm" class="notes-form">
         <div formArrayName="note" class="field">
           <label>Notes:</label>
@@ -1042,6 +1125,65 @@
         nbButton
         status="primary"
         (click)="confirmRoundChange(data.teamId, data.index, data.newValue); ref.close()"
+      >
+        Confirm
+      </button>
+      <button nbButton status="basic" (click)="ref.close()">Cancel</button>
+    </nb-card-footer>
+  </nb-card>
+</ng-template>
+
+<ng-template #trackChangedConfirmationDialogBox let-ref="dialogRef" let-data>
+  <nb-card class="confirmation-track-dialog-box">
+    <nb-card-header>
+      <span>Confirm Track Change</span>
+      <button nbButton ghost (click)="ref.close()" shape="round">
+        <nb-icon icon="close"></nb-icon>
+      </button>
+    </nb-card-header>
+    <nb-card-body>
+      <div class="confirmation-content">
+        <p>
+          Are you sure you want to change this team's track to <strong>{{ data.trackName }}</strong
+          >?
+        </p>
+      </div>
+    </nb-card-body>
+    <nb-card-footer>
+      <button
+        nbButton
+        status="primary"
+        (click)="confirmTrackChange(data.teamId, data.index, data.newValue); ref.close()"
+      >
+        Confirm
+      </button>
+      <button nbButton status="basic" (click)="ref.close()">Cancel</button>
+    </nb-card-footer>
+  </nb-card>
+</ng-template>
+
+<ng-template #problemStatementChangedConfirmationDialogBox let-ref="dialogRef" let-data>
+  <nb-card class="confirmation-problem-statement-dialog-box">
+    <nb-card-header>
+      <span>Confirm Problem Statement Change</span>
+      <button nbButton ghost (click)="ref.close()" shape="round">
+        <nb-icon icon="close"></nb-icon>
+      </button>
+    </nb-card-header>
+    <nb-card-body>
+      <div class="confirmation-content">
+        <p>
+          Are you sure you want to change this team's problem statement to
+          <strong>#{{ data.problemStatementName }}</strong
+          >?
+        </p>
+      </div>
+    </nb-card-body>
+    <nb-card-footer>
+      <button
+        nbButton
+        status="primary"
+        (click)="confirmProblemStatementChange(data.teamId, data.index, data.newValue); ref.close()"
       >
         Confirm
       </button>

--- a/apps/commudle-admin/src/app/feature-modules/hackathon-control-panel/components/hackathon-control-panel-review/hackathon-control-panel-review.component.scss
+++ b/apps/commudle-admin/src/app/feature-modules/hackathon-control-panel/components/hackathon-control-panel-review/hackathon-control-panel-review.component.scss
@@ -133,10 +133,12 @@ th {
   }
 }
 
-.round-select {
+.round-select,
+.track-select,
+.problem-statement-select {
   @apply com-my-4;
   select {
-    @apply com-border com-border-solid com-border-[#e4e9f2] com-px-2 com-py-2  com-rounded com-cursor-pointer com-w-full;
+    @apply com-bg-Custom-Select-Background com-border com-border-solid com-border-Bright-Gray com-cursor-pointer com-w-full com-rounded-lg com-h-10 com-mt-3 com-text-Yankees-Blue;
   }
 }
 
@@ -248,14 +250,6 @@ th {
   }
 }
 
-.confirmation-application-dialog-box,
-.confirmation-round-dialog-box {
-  nb-card-header,
-  nb-card-footer {
-    @apply com-flex com-justify-between com-items-center;
-  }
-}
-
 .form-responses-card {
   @apply com-m-0;
 }
@@ -321,5 +315,15 @@ th {
         }
       }
     }
+  }
+}
+
+.confirmation-application-dialog-box,
+.confirmation-round-dialog-box,
+.confirmation-track-dialog-box,
+.confirmation-problem-statement-dialog-box {
+  nb-card-header,
+  nb-card-footer {
+    @apply com-flex com-justify-between com-items-center;
   }
 }

--- a/apps/commudle-admin/src/app/feature-modules/hackathon-control-panel/components/hackathon-control-panel-review/hackathon-control-panel-review.component.ts
+++ b/apps/commudle-admin/src/app/feature-modules/hackathon-control-panel/components/hackathon-control-panel-review/hackathon-control-panel-review.component.ts
@@ -13,7 +13,14 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { HackathonService } from 'apps/commudle-admin/src/app/services/hackathon.service';
 import { IHackathonUserResponses } from 'apps/shared-models/hackathon-user-responses.model';
 import * as moment from 'moment';
-import { RoundService, ToastrService, NoteService, EmailerPreviewService, SeoService } from '@commudle/shared-services';
+import {
+  RoundService,
+  ToastrService,
+  NoteService,
+  EmailerPreviewService,
+  SeoService,
+  HackathonTeamService,
+} from '@commudle/shared-services';
 import { NbDialogRef, NbDialogService } from '@commudle/theme';
 import {
   EDbModels,
@@ -115,6 +122,8 @@ export class HackathonControlPanelReviewComponent implements OnInit, OnDestroy {
   };
   private originalStatusValue: EHackathonRegistrationStatus;
   private originalRoundValue: number;
+  private originalTrackValue: number;
+  private originalProblemStatementValue: number;
   private originalOfflineInviteStatusValue: EOfflineInviteStatus;
 
   tinyMCE = {
@@ -167,6 +176,7 @@ export class HackathonControlPanelReviewComponent implements OnInit, OnDestroy {
     private hackathonEmailPreview: EmailerPreviewService,
     private router: Router,
     private seoService: SeoService,
+    private hackathonTeamService: HackathonTeamService,
   ) {
     this.notesForm = this.fb.group({
       note: this.fb.array([]),
@@ -514,6 +524,14 @@ export class HackathonControlPanelReviewComponent implements OnInit, OnDestroy {
     this.originalRoundValue = value;
   }
 
+  storeOriginalTrackValue(value: number) {
+    this.originalTrackValue = value;
+  }
+
+  storeOriginalProblemStatementValue(value: number) {
+    this.originalProblemStatementValue = value;
+  }
+
   trackByTeamId(index: number, item: any): any {
     return item.team.id + '-' + item.team.registration_status;
   }
@@ -605,6 +623,96 @@ export class HackathonControlPanelReviewComponent implements OnInit, OnDestroy {
       const selectElement = document.getElementById(`round-select-${teamId}`) as HTMLSelectElement;
       if (selectElement) {
         selectElement.value = data.round.id.toString();
+      }
+
+      this.closeConfirmationDialogBox();
+    });
+  }
+
+  openTrackConfirmationDialogBox(templateRef, event, teamId: number, index: number) {
+    const selectedTrackId = event.target.value;
+    const selectedTrack = this.hackathonTracks.find((track) => track.id == selectedTrackId);
+    const previousValue = this.originalTrackValue;
+
+    // Revert the model first
+    if (this.selectedTeamDetails && previousValue) {
+      this.selectedTeamDetails.track = this.hackathonTracks.find((track) => track.id == previousValue);
+    }
+
+    // Then revert the visible select
+    event.target.value = previousValue?.toString() || '';
+
+    this.confirmationDialogReference = this.nbDialogService.open(templateRef, {
+      context: {
+        event: selectedTrackId,
+        trackName: selectedTrack?.name,
+        teamId: teamId,
+        index: index,
+        previousValue: previousValue,
+        newValue: selectedTrackId,
+      },
+    });
+  }
+
+  confirmTrackChange(teamId: number, index: number, newTrackId: number) {
+    this.hackathonTeamService.updateTrack(teamId, newTrackId).subscribe((data) => {
+      this.toastrService.successDialog('Details has been updated successfully');
+
+      // Update the model
+      if (index >= 0) {
+        this.userResponses[index].team = data;
+      }
+      this.selectedTeamDetails = data;
+
+      // Force DOM update
+      const selectElement = document.getElementById(`track-select-${teamId}`) as HTMLSelectElement;
+      if (selectElement) {
+        selectElement.value = data.track.id.toString();
+      }
+
+      this.closeConfirmationDialogBox();
+    });
+  }
+
+  openProblemStatementConfirmationDialogBox(templateRef, event, teamId: number, index: number) {
+    const selectedProblemStatementId = event.target.value;
+    const selectedProblemStatement = this.hackathonProblemStatements.find((ps) => ps.id == selectedProblemStatementId);
+    const previousValue = this.originalProblemStatementValue;
+
+    // Revert the model first
+    if (this.selectedTeamDetails && previousValue) {
+      this.selectedTeamDetails.problem_statement = this.hackathonProblemStatements.find((ps) => ps.id == previousValue);
+    }
+
+    // Then revert the visible select
+    event.target.value = previousValue?.toString() || '';
+
+    this.confirmationDialogReference = this.nbDialogService.open(templateRef, {
+      context: {
+        event: selectedProblemStatementId,
+        problemStatementName: selectedProblemStatement?.display_id,
+        teamId: teamId,
+        index: index,
+        previousValue: previousValue,
+        newValue: selectedProblemStatementId,
+      },
+    });
+  }
+
+  confirmProblemStatementChange(teamId: number, index: number, newProblemStatementId: number) {
+    this.hackathonTeamService.updateProblemStatement(teamId, newProblemStatementId).subscribe((data) => {
+      this.toastrService.successDialog('Details has been updated successfully');
+
+      // Update the model
+      if (index >= 0) {
+        this.userResponses[index].team.problem_statement = data.problem_statement;
+      }
+      this.selectedTeamDetails.problem_statement = data.problem_statement;
+
+      // Force DOM update
+      const selectElement = document.getElementById(`problem-statement-select-${teamId}`) as HTMLSelectElement;
+      if (selectElement) {
+        selectElement.value = data.problem_statement.id.toString();
       }
 
       this.closeConfirmationDialogBox();

--- a/apps/commudle-admin/src/app/feature-modules/hackathon-control-panel/components/hackathon-control-panel-review/hackathon-control-panel-review.component.ts
+++ b/apps/commudle-admin/src/app/feature-modules/hackathon-control-panel/components/hackathon-control-panel-review/hackathon-control-panel-review.component.ts
@@ -279,10 +279,6 @@ export class HackathonControlPanelReviewComponent implements OnInit, OnDestroy {
   indexTracks(hackathonId) {
     this.hackathonService.indexTracks(hackathonId).subscribe((data) => {
       this.hackathonTracks = data;
-      console.log(
-        '🚀 ~ HackathonControlPanelReviewComponent ~ indexTracks ~ this.hackathonTracks:',
-        this.hackathonTracks,
-      );
     });
   }
 

--- a/apps/commudle-admin/src/app/feature-modules/hackathon-control-panel/components/hackathon-control-panel-review/hackathon-control-panel-review.component.ts
+++ b/apps/commudle-admin/src/app/feature-modules/hackathon-control-panel/components/hackathon-control-panel-review/hackathon-control-panel-review.component.ts
@@ -279,6 +279,10 @@ export class HackathonControlPanelReviewComponent implements OnInit, OnDestroy {
   indexTracks(hackathonId) {
     this.hackathonService.indexTracks(hackathonId).subscribe((data) => {
       this.hackathonTracks = data;
+      console.log(
+        '🚀 ~ HackathonControlPanelReviewComponent ~ indexTracks ~ this.hackathonTracks:',
+        this.hackathonTracks,
+      );
     });
   }
 
@@ -784,5 +788,10 @@ export class HackathonControlPanelReviewComponent implements OnInit, OnDestroy {
         isBulkEmail: true,
       },
     });
+  }
+
+  getTrackProblemStatements(trackId: number) {
+    const track = this.hackathonTracks.find((t) => t.id === trackId);
+    return track?.hackathon_problem_statements || [];
   }
 }

--- a/libs/shared/services/src/index.ts
+++ b/libs/shared/services/src/index.ts
@@ -36,3 +36,4 @@ export * from './lib/hackathon-collaboration-communities.service';
 export * from './lib/hackathon-team-round-submission.service';
 export * from './lib/hackathon-team-round-score.service';
 export * from './lib/hackathon-entry-passes.service';
+export * from './lib/hackathon-team.service';

--- a/libs/shared/services/src/lib/api-routes.constant.ts
+++ b/libs/shared/services/src/lib/api-routes.constant.ts
@@ -903,6 +903,8 @@ export const API_ROUTES = {
     GENERATE_TEAM_REGISTRATION_STATUS_NOTIFICATION: 'api/v2/hackathons/generate_team_registration_status_notification', //POST
     SEND_TEAM_STATUS_EMAIL_BY_FILTER: 'api/v2/hackathons/send_team_status_email_by_filter', //POST
     CHANGE_TEAM_ROUND_STATUS: 'api/v2/hackathons/change_team_round_status', //PUT
+    CHANGE_TEAM_TRACK_STATUS: 'api/v2/hackathons/change_team_track_status', //PUT
+    CHANGE_TEAM_PROBLEM_STATEMENT_STATUS: 'api/v2/hackathons/change_team_problem_statement_status', //PUT
     GET_HACKATHON_CURRENT_REGISTRATION_DETAILS: 'api/v2/hackathons/get_hackathon_current_registration_details', //GET
     UPDATE_STATUS: 'api/v2/hackathons/update_status', //PUT
     VERIFY_INVITATION_TOKEN_JUDGE: 'api/v2/hackathons/verify_invitation_token_judge', //GET
@@ -935,6 +937,9 @@ export const API_ROUTES = {
       SEND_ENTRY_PASSES_EMAIL: 'api/v2/hackathons/teams/send_entry_passes_email', //POST
       SEND_RSVP_TO_ALL_TEAMS: 'api/v2/hackathons/teams/send_rsvp_to_all_teams', //POST
       SEND_ENTRY_PASSES_TO_ALL_TEAMS: 'api/v2/hackathons/teams/send_entry_passes_to_all_teams', //POST
+      TEAMS_BY_EVALUATOR: 'api/v2/hackathons/teams/teams_by_evaluator', //POST
+      UPDATE_TRACK: 'api/v2/hackathons/teams/update_track', //POST
+      UPDATE_PROBLEM_STATEMENT: 'api/v2/hackathons/teams/update_problem_statement',
     },
   },
 

--- a/libs/shared/services/src/lib/hackathon-team.service.ts
+++ b/libs/shared/services/src/lib/hackathon-team.service.ts
@@ -1,0 +1,43 @@
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { IHackathonTeam } from '@commudle/shared-models';
+import { API_ROUTES } from './api-routes.constant';
+import { BaseApiService } from './base-api.service';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class HackathonTeamService {
+  constructor(private http: HttpClient, private apiRoutesService: BaseApiService) {}
+
+  teamsByEvaluator(roundId: number, hackathonJudgeId: number): Observable<IHackathonTeam[]> {
+    const params = new HttpParams().set('round_id', roundId).set('hackathon_judge_id', hackathonJudgeId);
+    return this.http.get<IHackathonTeam[]>(
+      this.apiRoutesService.getRoute(API_ROUTES.HACKATHONS.TEAMS.TEAMS_BY_EVALUATOR),
+      {
+        params,
+      },
+    );
+  }
+
+  updateTrack(teamId: number, hackathonTrackId: number): Observable<IHackathonTeam> {
+    const params = new HttpParams().set('team_id', teamId).set('hackathon_track_id', hackathonTrackId);
+    return this.http.post<IHackathonTeam>(
+      this.apiRoutesService.getRoute(API_ROUTES.HACKATHONS.TEAMS.UPDATE_TRACK),
+      {},
+      { params },
+    );
+  }
+
+  updateProblemStatement(teamId: number, hackathonProblemStatementId: number): Observable<IHackathonTeam> {
+    const params = new HttpParams()
+      .set('team_id', teamId)
+      .set('hackathon_problem_statement_id', hackathonProblemStatementId);
+    return this.http.post<IHackathonTeam>(
+      this.apiRoutesService.getRoute(API_ROUTES.HACKATHONS.TEAMS.UPDATE_PROBLEM_STATEMENT),
+      {},
+      { params },
+    );
+  }
+}


### PR DESCRIPTION
- implemented track and problem statement dropdowns for hackathon teams
- added confirmation dialogs for track and problem statement changes
- integrated hackathon team service for updating track and problem statement
- updated api routes and shared services to support new endpoints
- enhanced ui with proper styling and conditional rendering <|im_end|>

# PR Template

## Type

- [ ] Fix
- [ ] Refactor
- [ ] Style
- [ ] Docs
- [X] Feat
- [ ] Hotfix
- [ ] Merge
- [ ] Revamp
- [ ] Chore

## Description

## Screenshots

## Testing

## Bundle Size
