### PR TITLE
fix(seo): return real HTTP 404/410 status to crawlers via SSR

### DIFF
--- a/apps/commudle-admin/src/server.ts
+++ b/apps/commudle-admin/src/server.ts
@@ -1,6 +1,7 @@
 import 'zone.js/node';
 
 import { APP_BASE_HREF } from '@angular/common';
+import { RESPONSE_INIT } from '@angular/core';
 import { CommonEngine } from '@angular/ssr/node';
 import compression from 'compression';
 import * as express from 'express';
@@ -74,15 +75,23 @@ export function app(): express.Express {
 
     const { protocol, originalUrl, baseUrl, headers } = req;
 
+    // Mutable object shared with the Angular app via DI.
+    // Components (e.g. Error404PageComponent) can set .status during ngOnInit
+    // so that the correct HTTP status is returned to the crawler.
+    const responseInit: ResponseInit = {};
+
     commonEngine
       .render({
         bootstrap: AppServerModule,
         documentFilePath: indexHtml,
         url: `${protocol}://${headers.host}${originalUrl}`,
         publicPath: distFolder,
-        providers: [{ provide: APP_BASE_HREF, useValue: baseUrl }],
+        providers: [
+          { provide: APP_BASE_HREF, useValue: baseUrl },
+          { provide: RESPONSE_INIT, useValue: responseInit },
+        ],
       })
-      .then((html) => res.send(html))
+      .then((html) => res.status((responseInit.status as number) ?? 200).send(html))
       .catch((err) => next(err));
   });
 

--- a/apps/commudle-admin/src/server.ts
+++ b/apps/commudle-admin/src/server.ts
@@ -91,7 +91,7 @@ export function app(): express.Express {
           { provide: RESPONSE_INIT, useValue: responseInit },
         ],
       })
-      .then((html) => res.status((responseInit.status as number) ?? 200).send(html))
+      .then((html) => res.status(responseInit.status ?? 200).send(html))
       .catch((err) => next(err));
   });
 

--- a/apps/lib-error-handler/src/lib/components/error404-page/error404-page.component.ts
+++ b/apps/lib-error-handler/src/lib/components/error404-page/error404-page.component.ts
@@ -1,14 +1,15 @@
-import { Component, OnDestroy, OnInit } from '@angular/core';
+import { isPlatformServer } from '@angular/common';
+import { Component, inject, OnDestroy, OnInit, PLATFORM_ID, RESPONSE_INIT } from '@angular/core';
 import { Router } from '@angular/router';
+import { SeoService } from '@commudle/shared-services';
 import { FooterService } from 'apps/commudle-admin/src/app/services/footer.service';
 import { ProfileStatusBarService } from 'apps/commudle-admin/src/app/services/profile-status-bar.service';
-import { SeoService } from '@commudle/shared-services';
 
 @Component({
-    selector: 'lib-error404-page',
-    templateUrl: './error404-page.component.html',
-    styleUrls: ['./error404-page.component.scss'],
-    standalone: false
+  selector: 'lib-error404-page',
+  templateUrl: './error404-page.component.html',
+  styleUrls: ['./error404-page.component.scss'],
+  standalone: false,
 })
 export class Error404PageComponent implements OnInit, OnDestroy {
   constructor(
@@ -23,9 +24,16 @@ export class Error404PageComponent implements OnInit, OnDestroy {
     this.profileStatusBarService.changeProfileBarStatus(false);
 
     const currentUrl = this.router.url;
-    const statusCode = currentUrl.includes('/410') ? '410' : '404';
+    const statusCode = currentUrl.includes('/410') ? 410 : 404;
 
-    this.seoService.setTag('prerender-status-code', statusCode);
+    // During SSR, signal the correct HTTP status back to Express via the
+    // shared RESPONSE_INIT object so crawlers receive a real 404/410 response.
+    if (isPlatformServer(inject(PLATFORM_ID))) {
+      const responseInit = inject(RESPONSE_INIT, { optional: true }) as ResponseInit | null;
+      if (responseInit) {
+        responseInit.status = statusCode;
+      }
+    }
 
     this.seoService.setTags(
       'Page Not Found - Commudle',
@@ -37,8 +45,5 @@ export class Error404PageComponent implements OnInit, OnDestroy {
   ngOnDestroy(): void {
     this.footerService.changeFooterStatus(false);
     this.profileStatusBarService.changeProfileBarStatus(true);
-
-    // Remove prerender-status-code meta tag when component is destroyed
-    this.seoService.removeTag('prerender-status-code');
   }
 }

--- a/apps/lib-error-handler/src/lib/components/error404-page/error404-page.component.ts
+++ b/apps/lib-error-handler/src/lib/components/error404-page/error404-page.component.ts
@@ -12,6 +12,10 @@ import { ProfileStatusBarService } from 'apps/commudle-admin/src/app/services/pr
   standalone: false,
 })
 export class Error404PageComponent implements OnInit, OnDestroy {
+  // inject() is only valid in injection context (field initializer / constructor), not in lifecycle hooks.
+  private readonly isServer = isPlatformServer(inject(PLATFORM_ID));
+  private readonly responseInit = inject(RESPONSE_INIT, { optional: true }) as ResponseInit | null;
+
   constructor(
     private profileStatusBarService: ProfileStatusBarService,
     private footerService: FooterService,
@@ -28,11 +32,8 @@ export class Error404PageComponent implements OnInit, OnDestroy {
 
     // During SSR, signal the correct HTTP status back to Express via the
     // shared RESPONSE_INIT object so crawlers receive a real 404/410 response.
-    if (isPlatformServer(inject(PLATFORM_ID))) {
-      const responseInit = inject(RESPONSE_INIT, { optional: true }) as ResponseInit | null;
-      if (responseInit) {
-        responseInit.status = statusCode;
-      }
+    if (this.isServer && this.responseInit) {
+      this.responseInit.status = statusCode;
     }
 
     this.seoService.setTags(

--- a/apps/lib-error-handler/src/lib/lib-error-handler.service.ts
+++ b/apps/lib-error-handler/src/lib/lib-error-handler.service.ts
@@ -1,4 +1,5 @@
-import { Injectable } from '@angular/core';
+import { inject, Injectable, PLATFORM_ID } from '@angular/core';
+import { isPlatformBrowser } from '@angular/common';
 import { Router } from '@angular/router';
 import { NbToastrService } from '@commudle/theme';
 import { LoginAuthService } from 'apps/shared-services/login-auth.service';
@@ -10,6 +11,8 @@ export class LibErrorHandlerService {
   errorCode: string;
   errorMessage: string;
 
+  private readonly isBrowser = isPlatformBrowser(inject(PLATFORM_ID));
+
   constructor(
     private toastrService: NbToastrService,
     private router: Router,
@@ -19,30 +22,39 @@ export class LibErrorHandlerService {
   handleError(errorCode, errorMessage) {
     this.errorCode = errorCode;
     this.errorMessage = errorMessage;
+
+    const ref = encodeURIComponent(this.router.url);
+
     switch (errorCode) {
       case 401:
-        this.loginAuthService.openLoginSignupTemplate();
+        if (this.isBrowser) {
+          this.loginAuthService.openLoginSignupTemplate();
+        }
         break;
       case 403:
         // redirect to unauthorized page
-        this.router.navigate([`/error/?ref=${encodeURIComponent(window.location.href)}`]);
+        this.router.navigate([`/error/?ref=${ref}`]);
         break;
       case 404:
-        this.router.navigate([`/404/?ref=${encodeURIComponent(window.location.href)}`]);
+        this.router.navigate([`/404/?ref=${ref}`]);
         break;
       case 410:
-        this.toastrService.show(errorCode, errorMessage, {
-          icon: '',
-          status: 'danger',
-        });
-        this.router.navigate([`/410/?ref=${encodeURIComponent(window.location.href)}`]);
+        if (this.isBrowser) {
+          this.toastrService.show(errorCode, errorMessage, {
+            icon: '',
+            status: 'danger',
+          });
+        }
+        this.router.navigate([`/410/?ref=${ref}`]);
         break;
       default:
         // show a toastr
-        this.toastrService.show(errorCode, errorMessage, {
-          icon: '',
-          status: 'danger',
-        });
+        if (this.isBrowser) {
+          this.toastrService.show(errorCode, errorMessage, {
+            icon: '',
+            status: 'danger',
+          });
+        }
         break;
     }
   }


### PR DESCRIPTION
## Problem

Previously, 404 and 410 responses to crawlers (Googlebot etc.) relied on the **Prerender service** reading a `<meta name="prerender-status-code">` tag from the rendered HTML and translating it into the correct HTTP status. Since the app now serves SSR directly to bots (bypassing Prerender), all pages — including missing and deleted ones — were returning HTTP **200** to crawlers, causing incorrect indexing.

Additionally, `LibErrorHandlerService.handleError()` accessed `window.location.href` unconditionally, which **threw a `ReferenceError` on the server** and prevented `router.navigate(['/404'])` from ever being called during SSR.

## Solution

Replace the prerender meta-tag hack with a proper Angular SSR mechanism using the `RESPONSE_INIT` DI token.

### How it works

1. **`server.ts`** — a mutable `ResponseInit` object is created per-request and provided to `CommonEngine.render()` via DI. After the Angular app finishes rendering, the Express handler reads back `responseInit.status` and calls `res.status(...)` accordingly.

2. **`Error404PageComponent`** — injects `RESPONSE_INIT` as a class field (valid injection context) and sets `.status = 404` or `.status = 410` during `ngOnInit`. On the browser, the token resolves to `null` (optional inject) so there is no browser-side impact.

3. **`LibErrorHandlerService`** — fixed SSR crashes:
   - `window.location.href` replaced with `this.router.url` (works on both platforms)
   - `toastrService.show()` and `loginAuthService.openLoginSignupTemplate()` guarded with `isBrowser` (both are DOM/browser-only)
   - `router.navigate(['/404'])` and `router.navigate(['/410'])` now run on the server too, so the Angular router renders `Error404PageComponent` during SSR and the status propagates back correctly

## Files changed

| File | Change |
|---|---|
| `apps/commudle-admin/src/server.ts` | Create `ResponseInit` per request, pass via `RESPONSE_INIT` provider, read status after render |
| `apps/lib-error-handler/src/lib/components/error404-page/error404-page.component.ts` | Inject `RESPONSE_INIT` + `PLATFORM_ID` as fields, set HTTP status on server, remove dead prerender meta tag |
| `apps/lib-error-handler/src/lib/lib-error-handler.service.ts` | Guard browser-only APIs, replace `window.location.href` with `this.router.url` |